### PR TITLE
feat: parse and format TRUNCATE TABLE

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -7,6 +7,10 @@ import (
 	"github.com/rpf3/sqlfmt/internal/parser"
 )
 
+func (f *formatter) formatTruncate(s *parser.TruncateStmt) string {
+	return f.kw("truncate table ") + s.Name + ";"
+}
+
 func (f *formatter) formatDrop(s *parser.DropStmt) string {
 	var b strings.Builder
 	b.WriteString(f.kw("drop "))

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -54,6 +54,8 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 		return f.formatAlterTable(s)
 	case *parser.DropStmt:
 		return f.formatDrop(s)
+	case *parser.TruncateStmt:
+		return f.formatTruncate(s)
 	case *parser.SelectStmt:
 		return f.formatSelectStmt(s)
 	}

--- a/internal/formatter/testdata/truncate.input.sql
+++ b/internal/formatter/testdata/truncate.input.sql
@@ -1,0 +1,2 @@
+TRUNCATE TABLE orders;
+TRUNCATE customers;

--- a/internal/formatter/testdata/truncate.sql
+++ b/internal/formatter/testdata/truncate.sql
@@ -1,0 +1,3 @@
+truncate table orders;
+
+truncate table customers;

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -122,6 +122,13 @@ type DropStmt struct {
 
 func (*DropStmt) statementNode() {}
 
+// TruncateStmt represents: TRUNCATE [TABLE] <name>
+type TruncateStmt struct {
+	Name string // table name
+}
+
+func (*TruncateStmt) statementNode() {}
+
 // ─── SELECT statement ─────────────────────────────────────────────────────────
 
 // SelectItem is one entry in a SELECT list.

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -626,3 +626,20 @@ func (p *parser) parseDataType() (string, error) {
 	}
 	return name + "(" + strings.Join(params, ", ") + ")", nil
 }
+
+// parseTruncate handles: TRUNCATE [TABLE] <name> [;]
+func (p *parser) parseTruncate() (Statement, error) {
+	p.advance() // consume TRUNCATE
+	if p.curKeyword("TABLE") {
+		p.advance() // consume optional TABLE
+	}
+	nameTok, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+	if p.curIs(lexer.Semicolon) {
+		p.advance()
+	}
+	stmt := &TruncateStmt{Name: nameTok.Value}
+	return stmt, nil
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -154,6 +154,9 @@ func (p *parser) parseStatement() (Statement, error) {
 	if p.curKeyword("WITH") {
 		return p.parseWithSelect()
 	}
+	if p.curKeyword("TRUNCATE") {
+		return p.parseTruncate()
+	}
 	return nil, fmt.Errorf(
 		"unexpected token %s %q at %d:%d",
 		p.cur.Type, p.cur.Value, p.cur.Line, p.cur.Column,


### PR DESCRIPTION
## Summary

- Adds `TruncateStmt` AST node
- Parses `TRUNCATE [TABLE] <name>` — the `TABLE` keyword is accepted but optional (both `TRUNCATE TABLE orders` and `TRUNCATE orders` parse correctly)
- Formatter always emits `truncate table <name>;` for consistency
- Golden test covers both variants of the input syntax

## Test plan

- [x] `go test ./...` passes (golden test + idempotency check in `TestFormatGolden` / `TestFormatIdempotent`)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)