### PR TITLE
feat: parse and format CREATE VIEW

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -7,6 +7,10 @@ import (
 	"github.com/rpf3/sqlfmt/internal/parser"
 )
 
+func (f *formatter) formatCreateView(s *parser.CreateViewStmt) string {
+	return f.kw("create view ") + s.Name + f.kw(" as") + "\n" + f.formatSelectStmt(s.Select)
+}
+
 func (f *formatter) formatTruncate(s *parser.TruncateStmt) string {
 	return f.kw("truncate table ") + s.Name + ";"
 }

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -56,6 +56,8 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 		return f.formatDrop(s)
 	case *parser.TruncateStmt:
 		return f.formatTruncate(s)
+	case *parser.CreateViewStmt:
+		return f.formatCreateView(s)
 	case *parser.SelectStmt:
 		return f.formatSelectStmt(s)
 	}

--- a/internal/formatter/testdata/create-view.input.sql
+++ b/internal/formatter/testdata/create-view.input.sql
@@ -1,0 +1,7 @@
+CREATE VIEW active_orders AS SELECT o.id, o.customer_id, o.total FROM orders AS o WHERE o.status = 'active';
+
+CREATE VIEW order_summary AS
+SELECT o.id, c.name AS customer_name, o.total
+FROM orders AS o
+JOIN customers AS c ON o.customer_id = c.id
+ORDER BY o.created_at DESC;

--- a/internal/formatter/testdata/create-view.sql
+++ b/internal/formatter/testdata/create-view.sql
@@ -1,0 +1,22 @@
+create view active_orders as
+select
+	o.id
+,	o.customer_id
+,	o.total
+from
+	orders as o
+where
+	o.status = 'active';
+
+create view order_summary as
+select
+	o.id
+,	c.name as customer_name
+,	o.total
+from
+	orders as o
+inner join
+	customers as c
+		on o.customer_id = c.id
+order by
+	o.created_at desc;

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -129,6 +129,14 @@ type TruncateStmt struct {
 
 func (*TruncateStmt) statementNode() {}
 
+// CreateViewStmt represents: CREATE VIEW <name> AS <select>
+type CreateViewStmt struct {
+	Name   string
+	Select *SelectStmt
+}
+
+func (*CreateViewStmt) statementNode() {}
+
 // ─── SELECT statement ─────────────────────────────────────────────────────────
 
 // SelectItem is one entry in a SELECT list.

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -225,6 +225,9 @@ func (p *parser) parseCreate() (Statement, error) {
 	if p.curKeyword("INDEX") {
 		return p.parseCreateIndex(false)
 	}
+	if p.curKeyword("VIEW") {
+		return p.parseCreateView()
+	}
 	return p.parseCreateTable()
 }
 
@@ -641,5 +644,38 @@ func (p *parser) parseTruncate() (Statement, error) {
 		p.advance()
 	}
 	stmt := &TruncateStmt{Name: nameTok.Value}
+	return stmt, nil
+}
+
+// parseCreateView handles: CREATE VIEW <name> AS <select> [;]
+func (p *parser) parseCreateView() (Statement, error) {
+	p.advance() // consume VIEW
+
+	nameTok, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.expectKeyword("AS"); err != nil {
+		return nil, err
+	}
+
+	if !p.curKeyword("SELECT") {
+		return nil, fmt.Errorf(
+			"expected SELECT after CREATE VIEW ... AS at %d:%d, got %s %q",
+			p.cur.Line, p.cur.Column, p.cur.Type, p.cur.Value,
+		)
+	}
+
+	sel, err := p.parseSelectCore()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.curIs(lexer.Semicolon) {
+		p.advance()
+	}
+
+	stmt := &CreateViewStmt{Name: nameTok.Value, Select: sel}
 	return stmt, nil
 }


### PR DESCRIPTION
## Summary

- Adds `CreateViewStmt` AST node with `Name string` and `Select *SelectStmt`
- Parses `CREATE VIEW <name> AS SELECT ...`
- Formatter outputs `create view <name> as\n` followed by the full formatted SELECT (including its trailing semicolon) — no extra semicolon handling required
- Golden test covers a simple filtered view and a view with a JOIN and ORDER BY

## Design note

The formatter reuses `formatSelectStmt` directly rather than stripping the semicolon as `indentCTE` and `indentSubquery` do. Because the CREATE VIEW header is simply a prefix line, the SELECT's own semicolon lands correctly at the end of the statement. WITH CTEs inside view bodies are not supported yet and will produce a parse error; that can be extended later.

## Test plan

- [x] `go test ./...` passes (`TestFormatGolden` + `TestFormatIdempotent` pick up the new golden pair automatically)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)