### PR TITLE
feat: parse and format DELETE

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -7,6 +7,44 @@ import (
 	"github.com/rpf3/sqlfmt/internal/parser"
 )
 
+func (f *formatter) formatDelete(s *parser.DeleteStmt) string {
+	ind := f.indent()
+	var b strings.Builder
+	if s.Alias != "" {
+		// Multi-line form: DELETE <alias> FROM <table> AS <alias>
+		b.WriteString(f.kw("delete"))
+		b.WriteString("\n")
+		b.WriteString(ind)
+		b.WriteString(s.Alias)
+		b.WriteString("\n")
+		b.WriteString(f.kw("from"))
+		b.WriteString("\n")
+		b.WriteString(ind)
+		b.WriteString(s.Table)
+		b.WriteString(f.kw(" as "))
+		b.WriteString(s.Alias)
+	} else if s.Where != "" {
+		// No alias but WHERE present: table on its own line for readability
+		b.WriteString(f.kw("delete from"))
+		b.WriteString("\n")
+		b.WriteString(ind)
+		b.WriteString(s.Table)
+	} else {
+		// No alias, no WHERE: compact single line
+		b.WriteString(f.kw("delete from "))
+		b.WriteString(s.Table)
+	}
+	if s.Where != "" {
+		b.WriteString("\n")
+		b.WriteString(f.kw("where"))
+		b.WriteString("\n")
+		b.WriteString(ind)
+		b.WriteString(s.Where)
+	}
+	b.WriteString(";")
+	return b.String()
+}
+
 func (f *formatter) formatCreateView(s *parser.CreateViewStmt) string {
 	return f.kw("create view ") + s.Name + f.kw(" as") + "\n" + f.formatSelectStmt(s.Select)
 }

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -58,6 +58,8 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 		return f.formatTruncate(s)
 	case *parser.CreateViewStmt:
 		return f.formatCreateView(s)
+	case *parser.DeleteStmt:
+		return f.formatDelete(s)
 	case *parser.SelectStmt:
 		return f.formatSelectStmt(s)
 	}

--- a/internal/formatter/testdata/delete.input.sql
+++ b/internal/formatter/testdata/delete.input.sql
@@ -1,0 +1,4 @@
+DELETE o FROM orders AS o WHERE o.status = 'cancelled' AND o.created_at < '2024-01-01';
+DELETE s FROM sessions AS s;
+DELETE FROM archive WHERE created_at < '2020-01-01';
+DELETE FROM staging;

--- a/internal/formatter/testdata/delete.sql
+++ b/internal/formatter/testdata/delete.sql
@@ -1,0 +1,18 @@
+delete
+	o
+from
+	orders as o
+where
+	o.status = 'cancelled' and o.created_at < '2024-01-01';
+
+delete
+	s
+from
+	sessions as s;
+
+delete from
+	archive
+where
+	created_at < '2020-01-01';
+
+delete from staging;

--- a/internal/linter/lint_dml.go
+++ b/internal/linter/lint_dml.go
@@ -1,0 +1,16 @@
+package linter
+
+import (
+	"fmt"
+
+	"github.com/rpf3/sqlfmt/internal/config"
+	"github.com/rpf3/sqlfmt/internal/parser"
+)
+
+func (l *linter) checkDeleteStmt(s *parser.DeleteStmt) {
+	// #34 alias-without-as
+	if s.Alias != "" && !s.AliasExplicit {
+		l.warn(config.RuleAliasWithoutAs,
+			fmt.Sprintf("table %q has a bare alias %q; use AS", s.Table, s.Alias))
+	}
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -60,6 +60,8 @@ func (l *linter) checkStatement(stmt parser.Statement) {
 		l.checkCreateIndex(s)
 	case *parser.SelectStmt:
 		l.checkSelectStmt(s)
+	case *parser.DeleteStmt:
+		l.checkDeleteStmt(s)
 	}
 }
 

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -137,6 +137,16 @@ type CreateViewStmt struct {
 
 func (*CreateViewStmt) statementNode() {}
 
+// DeleteStmt represents: DELETE [<alias>] FROM <table> [AS <alias>] [WHERE <predicate>]
+type DeleteStmt struct {
+	Table         string // table name
+	Alias         string // table alias; empty if none
+	AliasExplicit bool   // true when the AS keyword preceded the alias
+	Where         string // raw WHERE predicate; empty if absent
+}
+
+func (*DeleteStmt) statementNode() {}
+
 // ─── SELECT statement ─────────────────────────────────────────────────────────
 
 // SelectItem is one entry in a SELECT list.

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -679,3 +679,62 @@ func (p *parser) parseCreateView() (Statement, error) {
 	stmt := &CreateViewStmt{Name: nameTok.Value, Select: sel}
 	return stmt, nil
 }
+
+// parseDelete handles:
+//
+//	DELETE FROM <table> [AS <alias>] [WHERE <predicate>] [;]
+//	DELETE <alias> FROM <table> AS <alias> [WHERE <predicate>] [;]
+//
+// The second form is the SQL Server style where the target alias appears
+// before FROM as well as in the AS clause after the table name.
+func (p *parser) parseDelete() (Statement, error) {
+	p.advance() // consume DELETE
+
+	// Optional pre-FROM alias (SQL Server style: DELETE alias FROM ...).
+	// We detect it by checking whether the current token is an identifier
+	// immediately followed by the FROM keyword.
+	if (p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent)) && p.peekKeyword("FROM") {
+		p.advance() // consume alias — the AS clause after the table is authoritative
+	}
+
+	if err := p.expectKeyword("FROM"); err != nil {
+		return nil, err
+	}
+
+	nameTok, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &DeleteStmt{Table: nameTok.Value}
+
+	if p.curKeyword("AS") {
+		p.advance()
+		aliasTok, err := p.expectIdent()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Alias = aliasTok.Value
+		stmt.AliasExplicit = true
+	} else if (p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent)) && !p.curKeyword("WHERE") {
+		stmt.Alias = p.cur.Value
+		p.advance()
+	}
+
+	if p.curKeyword("WHERE") {
+		p.advance()
+		where, err := p.parseExprRaw(func() bool {
+			return p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
+		})
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	if p.curIs(lexer.Semicolon) {
+		p.advance()
+	}
+
+	return stmt, nil
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -157,6 +157,9 @@ func (p *parser) parseStatement() (Statement, error) {
 	if p.curKeyword("TRUNCATE") {
 		return p.parseTruncate()
 	}
+	if p.curKeyword("DELETE") {
+		return p.parseDelete()
+	}
 	return nil, fmt.Errorf(
 		"unexpected token %s %q at %d:%d",
 		p.cur.Type, p.cur.Value, p.cur.Line, p.cur.Column,


### PR DESCRIPTION
## Summary

- Adds `DeleteStmt` AST node with `Table`, `Alias`, `AliasExplicit`, and `Where` fields
- Accepts two input forms:
  - `DELETE FROM <table> [AS <alias>] [WHERE <predicate>]`
  - `DELETE <alias> FROM <table> AS <alias> [WHERE <predicate>]` (SQL Server style)
- Three formatter layouts depending on what is present:
  - Alias present → multi-line `delete` / `from` clause layout
  - No alias, WHERE present → `delete from` / indented table / `where` clause
  - No alias, no WHERE → compact single line
- Extends `alias-without-as` lint coverage to DELETE table references (see #13)
- Introduces `lint_dml.go` as the home for DML lint checks; INSERT and UPDATE will follow

## Design notes

The pre-FROM alias in `DELETE o FROM orders AS o` is consumed but discarded — the `AS` clause after the table name is treated as authoritative. This keeps the AST representation identical regardless of which input form is used.

The no-alias-with-WHERE layout (`delete from\n\t<table>`) mirrors the way SELECT renders its `from` clause, making the two statement types visually consistent when a predicate is present.

A follow-up lint rule `delete-without-where` has been filed as #80, which will warn when a `DELETE` has no `WHERE` clause (suggesting `TRUNCATE TABLE` instead for full-table clears).

## Test plan

- [x] `go test ./...` passes (golden test covers all four alias × WHERE combinations)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)