### PR TITLE
fix: emit DEFAULT on its own line after nullability in CREATE TABLE

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -114,19 +114,12 @@ func (f *formatter) normalizeDefaultExpr(v string) string {
 // writeColumnDef writes the canonical form of a column definition to b.
 // It does not include any leading indentation or comma — the caller handles that.
 func (f *formatter) writeColumnDef(b *strings.Builder, col parser.ColumnDef) {
+	ind := f.indent()
 	b.WriteString(col.Name)
 	b.WriteString(" ")
 	b.WriteString(f.kw(strings.ToLower(col.DataType)))
 	if col.PrimaryKey {
 		b.WriteString(" " + f.kw("primary key"))
-	}
-	if col.Default != "" {
-		if col.DefaultConstraint != "" {
-			b.WriteString(" " + f.kw("constraint") + " ")
-			b.WriteString(col.DefaultConstraint)
-		}
-		b.WriteString(" " + f.kw("default") + " ")
-		b.WriteString(f.normalizeDefaultExpr(col.Default))
 	}
 	switch col.Nullability {
 	case parser.NullabilityNotNull:
@@ -150,6 +143,17 @@ func (f *formatter) writeColumnDef(b *strings.Builder, col parser.ColumnDef) {
 			b.WriteString(strings.Join(col.References.Columns, ", "))
 			b.WriteString(")")
 		}
+	}
+	if col.Default != "" {
+		b.WriteString("\n")
+		b.WriteString(ind + ind)
+		if col.DefaultConstraint != "" {
+			b.WriteString(f.kw("constraint") + " ")
+			b.WriteString(col.DefaultConstraint)
+			b.WriteString(" ")
+		}
+		b.WriteString(f.kw("default") + " ")
+		b.WriteString(f.normalizeDefaultExpr(col.Default))
 	}
 }
 

--- a/internal/formatter/testdata/create-table.sql
+++ b/internal/formatter/testdata/create-table.sql
@@ -1,7 +1,8 @@
 create table ingredients
 (
 	id integer not null
-,	name varchar(255) constraint df_ingredients_name default 'unnamed' not null
+,	name varchar(255) not null
+		constraint df_ingredients_name default 'unnamed'
 
 ,	constraint pk_ingredients
 		primary key (id)
@@ -12,8 +13,10 @@ create table ingredients
 create table recipes
 (
 	id integer not null
-,	name varchar(255) constraint df_recipes_name default 'untitled' not null
-,	description varchar(1000) constraint df_recipes_description default null null
+,	name varchar(255) not null
+		constraint df_recipes_name default 'untitled'
+,	description varchar(1000) null
+		constraint df_recipes_description default null
 
 ,	constraint pk_recipes
 		primary key (id)

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -565,6 +565,37 @@ func (p *parser) parseColumnDef() (ColumnDef, error) {
 		col.Nullability = NullabilityNull
 	}
 
+	// CONSTRAINT <name> DEFAULT may also follow nullability (canonical formatter output).
+	if p.curKeyword("CONSTRAINT") {
+		p.advance() // consume CONSTRAINT
+		constrTok, err := p.expectIdent()
+		if err != nil {
+			return ColumnDef{}, err
+		}
+		if !p.curKeyword("DEFAULT") {
+			return ColumnDef{}, fmt.Errorf(
+				"expected DEFAULT after column CONSTRAINT name at %d:%d, got %s %q",
+				p.cur.Line, p.cur.Column, p.cur.Type, p.cur.Value,
+			)
+		}
+		col.DefaultConstraint = constrTok.Value
+	}
+
+	if p.curKeyword("DEFAULT") {
+		p.advance() // consume DEFAULT
+		tok := p.cur
+		switch tok.Type {
+		case lexer.StringLit, lexer.IntLit, lexer.FloatLit, lexer.Keyword, lexer.Ident:
+			col.Default = tok.Value
+			p.advance()
+		default:
+			return ColumnDef{}, fmt.Errorf(
+				"expected default value at %d:%d, got %s %q",
+				tok.Line, tok.Column, tok.Type, tok.Value,
+			)
+		}
+	}
+
 	if p.curKeyword("UNIQUE") {
 		p.advance() // consume UNIQUE
 		col.Unique = true


### PR DESCRIPTION
## Summary

- Moves the column `DEFAULT` clause (and its optional `CONSTRAINT` name) to a dedicated double-indented line that follows nullability, making the layout easier to scan
- Updates `parseColumnDef` to also accept `CONSTRAINT <name> DEFAULT` appearing *after* the nullability block, so the new canonical output round-trips through the parser without breaking idempotency
- Updates the `create-table.sql` golden file to reflect the new format

## Test plan

- [x] `go test ./...` passes (including `TestFormatNamedDefaultConstraint` and `TestFormatIdempotent`)
- [x] Golden test covers named DEFAULT with and without nullability (`NOT NULL`, `NULL`)
- [x] Verify formatter output before and after the fix matches the updated golden file

🤖 Generated with [Claude Code](https://claude.com/claude-code)