### PR TITLE
feat: DML lint rules (delete/update-without-where, insert-column-list)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,32 +43,34 @@ const (
 
 // Lint rule name constants — used in .sqlfmt.yml and referenced by the linter.
 const (
-	RuleInlinePrimaryKey  = "inline-primary-key"
-	RuleUnnamedPrimaryKey = "unnamed-primary-key"
-	RuleUnnamedDefault    = "unnamed-default"
-	RuleIndexDirection    = "index-direction"
-	RuleOrderByDirection  = "order-by-direction"
-	RuleAliasWithoutAs    = "alias-without-as"
-	RuleNoLimit           = "no-limit"
-	RuleOffsetRows        = "offset-rows"
-	RuleExistsSelectOne   = "exists-select-one"
+	RuleInlinePrimaryKey   = "inline-primary-key"
+	RuleUnnamedPrimaryKey  = "unnamed-primary-key"
+	RuleUnnamedDefault     = "unnamed-default"
+	RuleIndexDirection     = "index-direction"
+	RuleOrderByDirection   = "order-by-direction"
+	RuleAliasWithoutAs     = "alias-without-as"
+	RuleNoLimit            = "no-limit"
+	RuleOffsetRows         = "offset-rows"
+	RuleExistsSelectOne    = "exists-select-one"
 	RuleDeleteWithoutWhere = "delete-without-where"
 	RuleInsertColumnList   = "insert-column-list"
+	RuleUpdateWithoutWhere = "update-without-where"
 )
 
 // knownRules is the set of valid lint rule names for config validation.
 var knownRules = map[string]bool{
-	RuleInlinePrimaryKey:  true,
-	RuleUnnamedPrimaryKey: true,
-	RuleUnnamedDefault:    true,
-	RuleIndexDirection:    true,
-	RuleOrderByDirection:  true,
-	RuleAliasWithoutAs:    true,
-	RuleNoLimit:           true,
-	RuleOffsetRows:        true,
+	RuleInlinePrimaryKey:   true,
+	RuleUnnamedPrimaryKey:  true,
+	RuleUnnamedDefault:     true,
+	RuleIndexDirection:     true,
+	RuleOrderByDirection:   true,
+	RuleAliasWithoutAs:     true,
+	RuleNoLimit:            true,
+	RuleOffsetRows:         true,
 	RuleExistsSelectOne:    true,
 	RuleDeleteWithoutWhere: true,
 	RuleInsertColumnList:   true,
+	RuleUpdateWithoutWhere: true,
 }
 
 // Config holds all formatting and linting options for sqlfmt.

--- a/internal/linter/lint_dml.go
+++ b/internal/linter/lint_dml.go
@@ -14,6 +14,13 @@ func (l *linter) checkInsertStmt(s *parser.InsertStmt) {
 	}
 }
 
+func (l *linter) checkUpdateStmt(s *parser.UpdateStmt) {
+	if s.Where == "" {
+		l.warn(config.RuleUpdateWithoutWhere,
+			fmt.Sprintf("UPDATE on table %q has no WHERE clause", s.Target))
+	}
+}
+
 func (l *linter) checkDeleteStmt(s *parser.DeleteStmt) {
 	// #34 alias-without-as
 	if s.Alias != "" && !s.AliasExplicit {

--- a/internal/linter/lint_dml_test.go
+++ b/internal/linter/lint_dml_test.go
@@ -43,6 +43,43 @@ func TestLintInsertColumnList(t *testing.T) {
 	})
 }
 
+func TestLintUpdateWithoutWhere(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantRule string
+	}{
+		{
+			name:     "update without where warns",
+			input:    `update orders set status = 'shipped';`,
+			wantRule: config.RuleUpdateWithoutWhere,
+		},
+		{
+			name:     "update with where is clean",
+			input:    `update orders set status = 'shipped' where id = 42;`,
+			wantRule: "",
+		},
+		{
+			name:     "sql server update without where warns",
+			input:    `update o set o.status = 'shipped' from orders as o;`,
+			wantRule: config.RuleUpdateWithoutWhere,
+		},
+		{
+			name:     "sql server update with where is clean",
+			input:    `update o set o.status = 'shipped' from orders as o where o.id = 42;`,
+			wantRule: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkRule(t, tt.input, tt.wantRule)
+		})
+	}
+	t.Run("rule off suppresses warning", func(t *testing.T) {
+		checkRuleOff(t, `update orders set status = 'shipped';`, config.RuleUpdateWithoutWhere)
+	})
+}
+
 func TestLintDeleteWithoutWhere(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -62,6 +62,8 @@ func (l *linter) checkStatement(stmt parser.Statement) {
 		l.checkSelectStmt(s)
 	case *parser.InsertStmt:
 		l.checkInsertStmt(s)
+	case *parser.UpdateStmt:
+		l.checkUpdateStmt(s)
 	case *parser.DeleteStmt:
 		l.checkDeleteStmt(s)
 	}


### PR DESCRIPTION
## Summary

Three new lint rules for DML statements.

Closes #80, #100, #102

## Rules

**`delete-without-where`** — warns when a `DELETE` has no `WHERE` clause. A `DELETE` with no filter removes every row; `TRUNCATE TABLE` is the right tool when that is the intent.

**`insert-column-list`** — warns when an `INSERT` has no explicit column list. Omitting columns makes the statement depend on table column order, which breaks silently when the schema changes. Applies to both `INSERT … VALUES` and `INSERT … SELECT`.

**`update-without-where`** — warns when an `UPDATE` has no `WHERE` clause. An `UPDATE` with no filter modifies every row. Applies to both ANSI style and SQL Server `FROM` style.

All three rules default to `warn` and are suppressible via `.sqlfmt.yml`:

```yaml
lint:
  delete-without-where: off
  insert-column-list: off
  update-without-where: off
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)