### PR TITLE
feat: support T-SQL temp table name syntax (#name, ##name)

### DIFF
--- a/internal/formatter/testdata/temp_tables.input.sql
+++ b/internal/formatter/testdata/temp_tables.input.sql
@@ -1,0 +1,7 @@
+CREATE TABLE #staging (id INT NOT NULL, name VARCHAR(50) NOT NULL);
+
+INSERT INTO #staging (id, name) SELECT id, name FROM source;
+
+SELECT s.id, l.value FROM #staging AS s INNER JOIN ##shared_lookup AS l ON s.id = l.id;
+
+DROP TABLE #staging;

--- a/internal/formatter/testdata/temp_tables.sql
+++ b/internal/formatter/testdata/temp_tables.sql
@@ -1,0 +1,27 @@
+create table #staging
+(
+	id int not null
+,	name varchar(50) not null
+);
+
+insert into #staging
+(
+	id
+,	name
+)
+select
+	id
+,	name
+from
+	source;
+
+select
+	s.id
+,	l.value
+from
+	#staging as s
+inner join
+	##shared_lookup as l
+		on s.id = l.id;
+
+drop table #staging;

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -38,6 +38,18 @@ func (l *Lexer) Next() Token {
 		return l.readIdent()
 	}
 
+	// T-SQL temp table names: #local or ##global followed by identifier chars.
+	// A bare '#' with no following identifier is left to fall through to Illegal.
+	if ch == '#' {
+		next := l.peekAt(1)
+		if next == '#' && isIdentStart(l.peekAt(2)) {
+			return l.readTempTableIdent()
+		}
+		if isIdentStart(next) {
+			return l.readTempTableIdent()
+		}
+	}
+
 	// Numbers: digit or leading-dot float (.5)
 	if isDigit(ch) {
 		return l.readNumber()
@@ -240,6 +252,22 @@ func (l *Lexer) readIdent() Token {
 		tokenType = Keyword
 	}
 	return l.makeTokenAt(tokenType, word, line, col)
+}
+
+// readTempTableIdent scans a T-SQL temporary table name: #name or ##name.
+// The leading # or ## is included in the token value.
+// Called only when the '#' is followed by a valid identifier start character.
+func (l *Lexer) readTempTableIdent() Token {
+	line, col := l.line, l.column
+	start := l.pos
+	l.advance() // consume first '#'
+	if l.peek() == '#' {
+		l.advance() // consume second '#' for ##global
+	}
+	for l.pos < len(l.input) && isIdentContinue(l.input[l.pos]) {
+		l.advance()
+	}
+	return l.makeTokenAt(Ident, l.input[start:l.pos], line, col)
 }
 
 // readQuotedIdent scans a double-quoted identifier.

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -525,3 +525,43 @@ func TestTokenizeDotVsFloat(t *testing.T) {
 		t.Errorf(".5: got %v, want FloatLit", tokens2[0].Type)
 	}
 }
+
+// ─── Temp table names ─────────────────────────────────────────────────────────
+
+func TestTokenizeTempTableNames(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantType  TokenType
+		wantValue string
+	}{
+		{"#staging", Ident, "#staging"},
+		{"##global_temp", Ident, "##global_temp"},
+		{"#t1", Ident, "#t1"},
+		{"##x", Ident, "##x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			tokens := tokenize(t, tt.input)
+			if tokens[0].Type != tt.wantType {
+				t.Errorf("type: got %v, want %v", tokens[0].Type, tt.wantType)
+			}
+			if tokens[0].Value != tt.wantValue {
+				t.Errorf("value: got %q, want %q", tokens[0].Value, tt.wantValue)
+			}
+		})
+	}
+
+	t.Run("bare hash is illegal", func(t *testing.T) {
+		tok := New("#").Next()
+		if tok.Type != Illegal {
+			t.Errorf("bare #: got %v, want Illegal", tok.Type)
+		}
+	})
+
+	t.Run("hash before digit is illegal", func(t *testing.T) {
+		tok := New("#1bad").Next()
+		if tok.Type != Illegal {
+			t.Errorf("#1bad first token: got %v, want Illegal", tok.Type)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #93

## Implementation

The fix is entirely in the lexer. `Next()` now recognises `#` as the start of a T-SQL temporary table identifier when followed by a valid identifier-start character:

- `#staging` → `Ident` token with value `"#staging"`
- `##shared_lookup` → `Ident` token with value `"##shared_lookup"`
- bare `#` or `#1bad` → `Illegal` (unchanged)

A new `readTempTableIdent()` method consumes the `#` or `##` prefix and then reads identifier-continue characters as normal. No parser or formatter changes are required — temp table names slot into every existing table-name position as plain `Ident` tokens.

The golden test (`temp_tables.input.sql` → `temp_tables.sql`) exercises CREATE TABLE, INSERT INTO, SELECT with JOIN, and DROP TABLE against temp table names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)