### PR TITLE
refactor: migrate DML/DDL expression fields to Expr (phase 3 of #90)

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -30,7 +30,11 @@ func (f *formatter) formatInsert(s *parser.InsertStmt) string {
 	b.WriteString(f.kw("values"))
 	for i, row := range s.Values {
 		b.WriteString("\n(")
-		f.writeCommaList(&b, row)
+		rowStrs := make([]string, len(row))
+		for j, v := range row {
+			rowStrs[j] = parser.Render(v)
+		}
+		f.writeCommaList(&b, rowStrs)
 		b.WriteString("\n)")
 		if i < len(s.Values)-1 {
 			b.WriteString(",") // structural row separator, not a list comma
@@ -53,7 +57,7 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 
 	setStrs := make([]string, len(s.Sets))
 	for i, set := range s.Sets {
-		setStrs[i] = set.Column + " = " + set.Expr
+		setStrs[i] = set.Column + " = " + parser.Render(set.Value)
 	}
 	f.writeCommaList(&b, setStrs)
 
@@ -213,9 +217,9 @@ func (f *formatter) writeColumnDef(b *strings.Builder, col parser.ColumnDef) {
 	if col.Unique {
 		b.WriteString(" " + f.kw("unique"))
 	}
-	if col.Check != "" {
+	if col.Check != nil {
 		b.WriteString(" " + f.kw("check") + " (")
-		b.WriteString(col.Check)
+		b.WriteString(parser.Render(col.Check))
 		b.WriteString(")")
 	}
 	if col.References != nil {
@@ -227,7 +231,7 @@ func (f *formatter) writeColumnDef(b *strings.Builder, col parser.ColumnDef) {
 			b.WriteString(")")
 		}
 	}
-	if col.Default != "" {
+	if col.Default != nil {
 		b.WriteString("\n")
 		b.WriteString(ind + ind)
 		if col.DefaultConstraint != "" {
@@ -236,7 +240,7 @@ func (f *formatter) writeColumnDef(b *strings.Builder, col parser.ColumnDef) {
 			b.WriteString(" ")
 		}
 		b.WriteString(f.kw("default") + " ")
-		b.WriteString(f.normalizeDefaultExpr(col.Default))
+		b.WriteString(f.normalizeDefaultExpr(parser.Render(col.Default)))
 	}
 }
 
@@ -271,7 +275,7 @@ func (f *formatter) writeTableConstraint(b *strings.Builder, tc parser.TableCons
 		b.WriteString(")")
 	case parser.ConstraintCheck:
 		b.WriteString(f.kw("check") + " (")
-		b.WriteString(tc.Check)
+		b.WriteString(parser.Render(tc.Check))
 		b.WriteString(")")
 	}
 }
@@ -427,7 +431,7 @@ func (f *formatter) formatMerge(s *parser.MergeStmt) string {
 		case parser.MergeActionUpdate:
 			b.WriteString(f.kw(" update set"))
 			for i, set := range clause.Sets {
-				item := set.Column + " = " + set.Expr
+				item := set.Column + " = " + parser.Render(set.Value)
 				if i == 0 {
 					b.WriteString("\n" + ind + item)
 				} else {
@@ -452,9 +456,9 @@ func (f *formatter) formatMerge(s *parser.MergeStmt) string {
 			b.WriteString("\n(")
 			for i, val := range clause.Values {
 				if i == 0 {
-					b.WriteString("\n" + ind + val)
+					b.WriteString("\n" + ind + parser.Render(val))
 				} else {
-					b.WriteString("\n,\t" + val)
+					b.WriteString("\n,\t" + parser.Render(val))
 				}
 			}
 			b.WriteString("\n)")

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -99,7 +99,7 @@ func (l *linter) checkCreateTable(s *parser.CreateTableStmt) {
 				),
 			)
 		}
-		if col.Default != "" && col.DefaultConstraint == "" {
+		if col.Default != nil && col.DefaultConstraint == "" {
 			l.warn(
 				config.RuleUnnamedDefault,
 				fmt.Sprintf(

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -55,7 +55,7 @@ type TableConstraint struct {
 	Columns    []string // local column names (PK, FK)
 	RefTable   string   // for FK: referenced table name
 	RefColumns []string // for FK: referenced column names; empty means implicit PK reference
-	Check      string   // for CHECK: normalised expression text (without outer parens)
+	Check      Expr     // for CHECK: expression (without outer parens); nil for non-CHECK constraints
 }
 
 // Nullability represents an optional nullability constraint on a column.
@@ -153,7 +153,7 @@ func (*DeleteStmt) statementNode() {}
 type InsertStmt struct {
 	Table   string
 	Columns []string    // target column list; nil if no explicit column list
-	Values  [][]string  // rows of raw value expressions; nil if Select is set
+	Values  [][]Expr    // rows of value expressions; nil if Select is set
 	Select  *SelectStmt // INSERT … SELECT form; nil if Values is set
 }
 
@@ -174,7 +174,7 @@ func (*SetStmt) statementNode() {}
 // UpdateSet is one col = expr assignment in an UPDATE SET clause.
 type UpdateSet struct {
 	Column string // column name, possibly qualified (e.g. "o.status")
-	Expr   string // raw value expression (keywords normalised)
+	Value  Expr   // right-hand side expression
 }
 
 // UpdateFromSource is the FROM clause in a SQL Server style UPDATE.
@@ -228,7 +228,7 @@ type MergeWhenClause struct {
 	Action    MergeActionType
 	Sets      []UpdateSet // for MergeActionUpdate
 	Columns   []string    // for MergeActionInsert: column list; nil if absent
-	Values    []string    // for MergeActionInsert: single row of value expressions
+	Values    []Expr      // for MergeActionInsert: single row of value expressions
 }
 
 // MergeStmt represents a MERGE statement.
@@ -326,9 +326,9 @@ type ColumnDef struct {
 	DataType          string           // e.g. "INTEGER", "TEXT", "VARCHAR(255)", "NUMERIC(10, 2)"
 	PrimaryKey        bool             // PRIMARY KEY inline constraint
 	DefaultConstraint string           // optional CONSTRAINT name preceding DEFAULT; empty if unnamed
-	Default           string           // DEFAULT expression verbatim; empty means no DEFAULT clause
+	Default           Expr             // DEFAULT expression; nil means no DEFAULT clause
 	Nullability       Nullability      // optional nullability constraint
 	Unique            bool             // UNIQUE inline constraint
-	Check             string           // optional inline CHECK expression (without outer parens); empty if absent
+	Check             Expr             // optional inline CHECK expression (without outer parens); nil if absent
 	References        *ColumnReference // optional inline REFERENCES clause
 }

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -443,19 +443,20 @@ func (p *parser) parseTableConstraint() (TableConstraint, error) {
 }
 
 // parseCheckExpr parses the parenthesised body of a CHECK constraint and
-// returns a normalised expression string (keywords lowercased, tokens
-// space-joined, outer parens stripped). Nested parens are handled via a
-// depth counter so expressions like CHECK (x IN (1, 2)) are captured whole.
-func (p *parser) parseCheckExpr() (string, error) {
+// returns a RawExpr containing the normalised expression text (keywords
+// lowercased, tokens space-joined, outer parens stripped). Nested parens are
+// handled via a depth counter so expressions like CHECK (x IN (1, 2)) are
+// captured whole.
+func (p *parser) parseCheckExpr() (Expr, error) {
 	if _, err := p.expect(lexer.LParen); err != nil {
-		return "", err
+		return nil, err
 	}
 	var parts []string
 	depth := 1
 	for {
 		tok := p.cur
 		if tok.Type == lexer.EOF {
-			return "", fmt.Errorf("unterminated CHECK expression at %d:%d", tok.Line, tok.Column)
+			return nil, fmt.Errorf("unterminated CHECK expression at %d:%d", tok.Line, tok.Column)
 		}
 		if tok.Type == lexer.RParen {
 			depth--
@@ -472,7 +473,7 @@ func (p *parser) parseCheckExpr() (string, error) {
 		}
 		p.advance()
 	}
-	return strings.Join(parts, " "), nil
+	return &RawExpr{Text: strings.Join(parts, " ")}, nil
 }
 
 // parseReferences parses: REFERENCES <table> [( <columns> )]
@@ -537,7 +538,7 @@ func (p *parser) parseColumnDef() (ColumnDef, error) {
 		tok := p.cur
 		switch tok.Type {
 		case lexer.StringLit, lexer.IntLit, lexer.FloatLit, lexer.Keyword, lexer.Ident:
-			col.Default = tok.Value
+			col.Default = &RawExpr{Text: tok.Value}
 			p.advance()
 		default:
 			return ColumnDef{}, fmt.Errorf(
@@ -578,7 +579,7 @@ func (p *parser) parseColumnDef() (ColumnDef, error) {
 		tok := p.cur
 		switch tok.Type {
 		case lexer.StringLit, lexer.IntLit, lexer.FloatLit, lexer.Keyword, lexer.Ident:
-			col.Default = tok.Value
+			col.Default = &RawExpr{Text: tok.Value}
 			p.advance()
 		default:
 			return ColumnDef{}, fmt.Errorf(
@@ -764,18 +765,15 @@ func (p *parser) parseInsert() (Statement, error) {
 }
 
 // parseValueRow parses one parenthesised list of value expressions: (expr, expr, ...)
-func (p *parser) parseValueRow() ([]string, error) {
+func (p *parser) parseValueRow() ([]Expr, error) {
 	if _, err := p.expect(lexer.LParen); err != nil {
 		return nil, err
 	}
-	var exprs []string
+	var exprs []Expr
 	for {
-		expr, err := p.parseExprRaw(func() bool {
+		expr := p.parseExpr(func() bool {
 			return p.curIs(lexer.Comma) || p.curIs(lexer.RParen)
 		})
-		if err != nil {
-			return nil, err
-		}
 		exprs = append(exprs, expr)
 		if !p.curIs(lexer.Comma) {
 			break
@@ -888,17 +886,14 @@ func (p *parser) parseSetClause() ([]UpdateSet, error) {
 			return nil, err
 		}
 
-		expr, err := p.parseExprRaw(func() bool {
+		expr := p.parseExpr(func() bool {
 			return p.curIs(lexer.Comma) ||
 				p.curKeyword("WHERE") ||
 				p.curKeyword("FROM") ||
 				p.curIs(lexer.Semicolon) ||
 				p.curIs(lexer.EOF)
 		})
-		if err != nil {
-			return nil, err
-		}
-		sets = append(sets, UpdateSet{Column: colName, Expr: expr})
+		sets = append(sets, UpdateSet{Column: colName, Value: expr})
 
 		if !p.curIs(lexer.Comma) {
 			break
@@ -1171,16 +1166,13 @@ func (p *parser) parseMergeSetClause() ([]UpdateSet, error) {
 		if _, err := p.expect(lexer.Eq); err != nil {
 			return nil, err
 		}
-		expr, err := p.parseExprRaw(func() bool {
+		expr := p.parseExpr(func() bool {
 			return p.curIs(lexer.Comma) ||
 				p.curKeyword("WHEN") ||
 				p.curIs(lexer.Semicolon) ||
 				p.curIs(lexer.EOF)
 		})
-		if err != nil {
-			return nil, err
-		}
-		sets = append(sets, UpdateSet{Column: colName, Expr: expr})
+		sets = append(sets, UpdateSet{Column: colName, Value: expr})
 		if !p.curIs(lexer.Comma) {
 			break
 		}


### PR DESCRIPTION
## Summary

- Renames `UpdateSet.Expr string` → `UpdateSet.Value Expr` (avoids `Expr Expr` field/type collision, consistent with Phase 2)
- Changes `InsertStmt.Values [][]string` → `[][]Expr`
- Changes `MergeWhenClause.Values []string` → `[]Expr`
- Changes `ColumnDef.Default string` → `Expr` (nil = absent)
- Changes `ColumnDef.Check string` → `Expr` (nil = absent)
- Changes `TableConstraint.Check string` → `Expr` (nil = absent)

## Why

Final phase of the structured AST migration (#90). All expression-typed fields across the entire AST are now `Expr` rather than raw strings, unblocking identifier naming lint (#20), missing-schema lint (#14), identifier-with-spaces lint (#61), and quote_identifiers config (#60).

## Key design choices

- `parseCheckExpr` return type changed from `(string, error)` to `(Expr, error)` — wraps its internally assembled string in `&RawExpr{}`; the internal token-reading logic is unchanged
- `parseValueRow` returns `([]Expr, error)` using `parseExpr` per element  
- `ColumnDef.Default` wraps its single token in `&RawExpr{Text: tok.Value}`; the formatter continues to call `normalizeDefaultExpr(parser.Render(col.Default))` — since `Render(&RawExpr{s}) == s`, keyword normalisation is byte-identical
- Formatter nil-checks (`col.Default != nil`, `col.Check != nil`) replace empty-string checks

## Test plan

- [ ] `go build ./...` — clean compile
- [ ] `go test ./...` — all golden and idempotency tests pass byte-identical
- [ ] `task fmt && task test && task vet && task lint` — full check suite green

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)