### PR TITLE
feat: break multi-AND WHERE/HAVING/ON predicates across lines (#101)

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -84,11 +84,8 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 	}
 
 	if s.Where != nil {
-		b.WriteString("\n")
-		b.WriteString(f.kw("where"))
-		b.WriteString("\n")
-		b.WriteString(ind)
-		b.WriteString(parser.Render(s.Where))
+		b.WriteString("\n" + f.kw("where"))
+		f.writeExprPred(&b, s.Where)
 	}
 	b.WriteString(";")
 	return b.String()
@@ -122,11 +119,8 @@ func (f *formatter) formatDelete(s *parser.DeleteStmt) string {
 		b.WriteString(s.Table)
 	}
 	if s.Where != nil {
-		b.WriteString("\n")
-		b.WriteString(f.kw("where"))
-		b.WriteString("\n")
-		b.WriteString(ind)
-		b.WriteString(parser.Render(s.Where))
+		b.WriteString("\n" + f.kw("where"))
+		f.writeExprPred(&b, s.Where)
 	}
 	b.WriteString(";")
 	return b.String()

--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -114,7 +114,11 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 			b.WriteString(" " + f.kw("as") + " " + jc.Alias)
 		}
 		if jc.On != nil {
-			b.WriteString("\n" + ind + ind + f.kw("on") + " " + parser.Render(jc.On))
+			terms := parser.AndTerms(jc.On)
+			b.WriteString("\n" + ind + ind + f.kw("on") + " " + parser.Render(terms[0]))
+			for _, term := range terms[1:] {
+				b.WriteString("\n" + ind + ind + f.kw("and") + " " + parser.Render(term))
+			}
 		} else if len(jc.Using) > 0 {
 			b.WriteString("\n" + ind + ind + f.kw("using") + " (" + strings.Join(jc.Using, ", ") + ")")
 		}
@@ -123,8 +127,7 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 	// WHERE
 	if s.Where != nil {
 		b.WriteString("\n" + f.kw("where"))
-		b.WriteString("\n" + ind)
-		b.WriteString(parser.Render(s.Where))
+		f.writeExprPred(&b, s.Where)
 	} else if s.WhereSubq != nil {
 		b.WriteString("\n" + f.kw("where"))
 		if s.WherePred != "" {
@@ -148,8 +151,7 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 	// HAVING
 	if s.Having != nil {
 		b.WriteString("\n" + f.kw("having"))
-		b.WriteString("\n" + ind)
-		b.WriteString(parser.Render(s.Having))
+		f.writeExprPred(&b, s.Having)
 	}
 
 	// ORDER BY

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -74,6 +74,21 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 	return ""
 }
 
+// writeExprPred writes a predicate expression as one indented line per AND term.
+// It must be called immediately after the caller writes the keyword (WHERE,
+// HAVING) on its own line. Single-term expressions produce one indented line.
+// Multi-term AndChain expressions produce one line per term: the first at one
+// indent, subsequent terms prefixed with "and" + indent, mirroring the
+// leading-comma style used for column lists.
+func (f *formatter) writeExprPred(b *strings.Builder, e parser.Expr) {
+	ind := f.indent()
+	terms := parser.AndTerms(e)
+	b.WriteString("\n" + ind + parser.Render(terms[0]))
+	for _, term := range terms[1:] {
+		b.WriteString("\n" + f.kw("and") + ind + parser.Render(term))
+	}
+}
+
 // writeCommaList writes a list of pre-formatted items to b using the configured
 // comma style. Each item is placed on its own line with one level of indentation.
 func (f *formatter) writeCommaList(b *strings.Builder, items []string) {

--- a/internal/formatter/testdata/delete.sql
+++ b/internal/formatter/testdata/delete.sql
@@ -3,7 +3,8 @@ delete
 from
 	orders as o
 where
-	o.status = 'cancelled' and o.created_at < '2024-01-01';
+	o.status = 'cancelled'
+and	o.created_at < '2024-01-01';
 
 delete
 	s

--- a/internal/formatter/testdata/select.input.sql
+++ b/internal/formatter/testdata/select.input.sql
@@ -20,3 +20,6 @@ WITH active_orders AS (SELECT t.id,t.customer_id FROM orders AS t WHERE t.status
 SELECT t.id,t.customer_id,t.total_amount,row_number() OVER (PARTITION BY t.customer_id ORDER BY t.created_at DESC) AS rn FROM orders AS t;
 SELECT t.id,t.total_amount,rank() OVER (ORDER BY t.total_amount DESC) AS amount_rank FROM orders AS t;
 SELECT DISTINCT c.id,c.name AS customer_name,sum(o.total_amount) AS lifetime_value,count(o.id) AS order_count,row_number() OVER (ORDER BY sum(o.total_amount) DESC) AS value_rank FROM customers AS c INNER JOIN orders AS o ON o.customer_id = c.id WHERE c.created_at >= '2024-01-01' GROUP BY c.id,c.name HAVING sum(o.total_amount) > 1000 ORDER BY lifetime_value DESC FETCH NEXT 100 ROWS ONLY;
+SELECT t.id,t.name FROM orders AS t WHERE t.status = 'active' AND t.region = 'us' AND t.amount > 100;
+SELECT t.status,count(*) AS order_count FROM orders AS t GROUP BY t.status HAVING count(*) > 10 AND sum(t.amount) > 1000;
+SELECT o.id,o.status FROM orders AS o INNER JOIN customers AS c ON c.id = o.customer_id AND c.active = 1 WHERE o.status = 'active' AND o.total_amount > 0;

--- a/internal/formatter/testdata/select.sql
+++ b/internal/formatter/testdata/select.sql
@@ -271,3 +271,37 @@ order by
 	lifetime_value desc
 fetch next
 	100 rows only;
+
+select
+	t.id
+,	t.name
+from
+	orders as t
+where
+	t.status = 'active'
+and	t.region = 'us'
+and	t.amount > 100;
+
+select
+	t.status
+,	count(*) as order_count
+from
+	orders as t
+group by
+	t.status
+having
+	count(*) > 10
+and	sum(t.amount) > 1000;
+
+select
+	o.id
+,	o.status
+from
+	orders as o
+inner join
+	customers as c
+		on c.id = o.customer_id
+		and c.active = 1
+where
+	o.status = 'active'
+and	o.total_amount > 0;

--- a/internal/formatter/testdata/update.sql
+++ b/internal/formatter/testdata/update.sql
@@ -40,4 +40,5 @@ set
 from
 	orders as o
 where
-	o.id = 1 and o.active = 1;
+	o.id = 1
+and	o.active = 1;

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -815,7 +815,7 @@ func (p *parser) parseUpdate() (Statement, error) {
 
 	if p.curKeyword("WHERE") {
 		p.advance()
-		stmt.Where = p.parseExpr(func() bool {
+		stmt.Where = p.parseAndChain(func() bool {
 			return p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
 		})
 	}
@@ -946,7 +946,7 @@ func (p *parser) parseDelete() (Statement, error) {
 
 	if p.curKeyword("WHERE") {
 		p.advance()
-		stmt.Where = p.parseExpr(func() bool {
+		stmt.Where = p.parseAndChain(func() bool {
 			return p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `writeExprPred` helper to `formatter.go` — writes a predicate `Expr` as one indented line per AND term, using leading `and\t` style matching the existing leading-comma convention for column lists
- `format_select.go`: WHERE and HAVING use `writeExprPred`; JOIN ON expands inline with double-indent `and` continuations
- `format_ddl.go`: UPDATE and DELETE WHERE use `writeExprPred`
- `parse_ddl.go`: UPDATE and DELETE WHERE parsers changed from `parseExpr` → `parseAndChain` so AND terms are structurally split (SELECT WHERE/HAVING already used `parseAndChain` since #117)

## Output example

```sql
-- before
where
	o.status = 'active' and o.region = 'us' and o.amount > 100

-- after
where
	o.status = 'active'
and	o.region = 'us'
and	o.amount > 100
```

JOIN ON with multiple conditions:
```sql
inner join
	customers as c
		on c.id = o.customer_id
		and c.active = 1
```

## Test plan

- [ ] `go build ./...` — clean compile
- [ ] `go test ./...` — all golden and idempotency tests pass; three new SELECT cases cover multi-AND WHERE, HAVING, and JOIN ON
- [ ] `task fmt && task test && task vet && task lint` — full check suite green

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)