### PR TITLE
chore: use indented 'and' style for multi-AND predicates (#121)

### DIFF
--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -77,15 +77,14 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 // writeExprPred writes a predicate expression as one indented line per AND term.
 // It must be called immediately after the caller writes the keyword (WHERE,
 // HAVING) on its own line. Single-term expressions produce one indented line.
-// Multi-term AndChain expressions produce one line per term: the first at one
-// indent, subsequent terms prefixed with "and" + indent, mirroring the
-// leading-comma style used for column lists.
+// Multi-term AndChain expressions produce one line per term, all at the same
+// indent level: the first term plain, subsequent terms prefixed with "and ".
 func (f *formatter) writeExprPred(b *strings.Builder, e parser.Expr) {
 	ind := f.indent()
 	terms := parser.AndTerms(e)
 	b.WriteString("\n" + ind + parser.Render(terms[0]))
 	for _, term := range terms[1:] {
-		b.WriteString("\n" + f.kw("and") + ind + parser.Render(term))
+		b.WriteString("\n" + ind + f.kw("and") + " " + parser.Render(term))
 	}
 }
 

--- a/internal/formatter/testdata/delete.sql
+++ b/internal/formatter/testdata/delete.sql
@@ -4,7 +4,7 @@ from
 	orders as o
 where
 	o.status = 'cancelled'
-and	o.created_at < '2024-01-01';
+	and o.created_at < '2024-01-01';
 
 delete
 	s

--- a/internal/formatter/testdata/select.sql
+++ b/internal/formatter/testdata/select.sql
@@ -279,8 +279,8 @@ from
 	orders as t
 where
 	t.status = 'active'
-and	t.region = 'us'
-and	t.amount > 100;
+	and t.region = 'us'
+	and t.amount > 100;
 
 select
 	t.status
@@ -291,7 +291,7 @@ group by
 	t.status
 having
 	count(*) > 10
-and	sum(t.amount) > 1000;
+	and sum(t.amount) > 1000;
 
 select
 	o.id
@@ -304,4 +304,4 @@ inner join
 		and c.active = 1
 where
 	o.status = 'active'
-and	o.total_amount > 0;
+	and o.total_amount > 0;

--- a/internal/formatter/testdata/update.sql
+++ b/internal/formatter/testdata/update.sql
@@ -41,4 +41,4 @@ from
 	orders as o
 where
 	o.id = 1
-and	o.active = 1;
+	and o.active = 1;


### PR DESCRIPTION
## Summary

- Changes AND continuation style from leading (`and` at column 0) to indented (`and` at the same indent as the first term), matching how JOIN ON continuations were already rendered
- One-line change to `writeExprPred` in `formatter.go`; golden files for `select`, `update`, and `delete` updated to match

## Before / After

```sql
-- before
where
	a = 1
and	b = 2

-- after
where
	a = 1
	and b = 2
```

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)