### PR TITLE
feat: normalise built-in function names to lowercase

### DIFF
--- a/internal/formatter/testdata/create_view_with.sql
+++ b/internal/formatter/testdata/create_view_with.sql
@@ -4,7 +4,7 @@ with ranked as
 	select
 		customer_id
 	,	total
-	,	ROW_NUMBER() over (partition by customer_id order by created_at desc) as rn
+	,	row_number() over (partition by customer_id order by created_at desc) as rn
 	from
 		orders
 )

--- a/internal/formatter/testdata/select.input.sql
+++ b/internal/formatter/testdata/select.input.sql
@@ -23,3 +23,4 @@ SELECT DISTINCT c.id,c.name AS customer_name,sum(o.total_amount) AS lifetime_val
 SELECT t.id,t.name FROM orders AS t WHERE t.status = 'active' AND t.region = 'us' AND t.amount > 100;
 SELECT t.status,count(*) AS order_count FROM orders AS t GROUP BY t.status HAVING count(*) > 10 AND sum(t.amount) > 1000;
 SELECT o.id,o.status FROM orders AS o INNER JOIN customers AS c ON c.id = o.customer_id AND c.active = 1 WHERE o.status = 'active' AND o.total_amount > 0;
+SELECT COUNT(*) AS total,SUM(t.amount) AS revenue,AVG(t.amount) AS avg_amount FROM orders AS t;

--- a/internal/formatter/testdata/select.sql
+++ b/internal/formatter/testdata/select.sql
@@ -305,3 +305,10 @@ inner join
 where
 	o.status = 'active'
 	and o.total_amount > 0;
+
+select
+	count(*) as total
+,	sum(t.amount) as revenue
+,	avg(t.amount) as avg_amount
+from
+	orders as t;

--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -6,10 +6,44 @@ import (
 	"github.com/rpf3/sqlfmt/internal/lexer"
 )
 
+// builtinFunctions is the set of SQL built-in function names that sqlfmt
+// normalises to lowercase regardless of how they appear in the source.
+var builtinFunctions = map[string]bool{
+	// Aggregate
+	"COUNT": true, "SUM": true, "AVG": true, "MAX": true, "MIN": true,
+	"STRING_AGG": true, "LISTAGG": true, "GROUP_CONCAT": true,
+	// Window
+	"ROW_NUMBER": true, "RANK": true, "DENSE_RANK": true, "NTILE": true,
+	"LAG": true, "LEAD": true, "FIRST_VALUE": true, "LAST_VALUE": true,
+	"CUME_DIST": true, "PERCENT_RANK": true,
+	// Null / conditional
+	"COALESCE": true, "NULLIF": true, "ISNULL": true, "NVL": true,
+	"IFNULL": true, "IIF": true,
+	// String
+	"UPPER": true, "LOWER": true, "TRIM": true, "LTRIM": true, "RTRIM": true,
+	"LEN": true, "LENGTH": true, "SUBSTRING": true, "SUBSTR": true,
+	"REPLACE": true, "CHARINDEX": true, "PATINDEX": true, "STUFF": true,
+	"CONCAT": true,
+	// Date / time
+	"GETDATE": true, "NOW": true, "DATEADD": true, "DATEDIFF": true,
+	"DATEPART": true, "DATENAME": true, "YEAR": true, "MONTH": true, "DAY": true,
+	"EOMONTH": true, "SYSDATETIME": true, "FORMAT": true,
+	// Type conversion (CAST is already a keyword)
+	"CONVERT": true, "TRY_CAST": true, "TRY_CONVERT": true,
+	"PARSE": true, "TRY_PARSE": true,
+	// Numeric
+	"ROUND": true, "FLOOR": true, "CEILING": true,
+	"ABS": true, "POWER": true, "SQRT": true, "SIGN": true,
+}
+
 // exprToken returns the normalised string for a single expression token:
-// keywords are lowercased; everything else is preserved verbatim.
+// keywords are lowercased; known built-in function names are lowercased;
+// everything else is preserved verbatim.
 func exprToken(tok lexer.Token) string {
 	if tok.Type == lexer.Keyword {
+		return strings.ToLower(tok.Value)
+	}
+	if tok.Type == lexer.Ident && builtinFunctions[strings.ToUpper(tok.Value)] {
 		return strings.ToLower(tok.Value)
 	}
 	return tok.Value


### PR DESCRIPTION
## Summary

- Adds `builtinFunctions` map to `internal/parser/parse_expr.go` covering ~50 built-in SQL function names across aggregate, window, string, date/time, type-conversion, and numeric categories
- Extends `exprToken()` with a three-line check: when an `Ident` token's uppercase form is in the map, return its lowercase form — exactly parallel to the existing keyword-lowercasing path
- Updates golden files: `create_view_with.sql` (`ROW_NUMBER` → `row_number`) and a new `SELECT COUNT/SUM/AVG` round-trip test case

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)