### PR TITLE
feat: release pipeline with GoReleaser, svu, and --version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Run tests
+        run: go test ./...
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,34 @@
+version: 2
+
+builds:
+  - id: sqlfmt
+    main: ./cmd/sqlfmt
+    binary: sqlfmt
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^chore:"
+      - "^docs:"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   build:
     desc: Build the sqlfmt binary to ./bin/sqlfmt
     cmds:
-      - go build -o ./bin/sqlfmt ./cmd/sqlfmt
+      - go build -ldflags "-X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o ./bin/sqlfmt ./cmd/sqlfmt
 
   run:
     desc: Run sqlfmt (reads SQL from stdin, e.g. echo "SELECT 1" | task run)
@@ -33,3 +33,12 @@ tasks:
         msg: golangci-lint not found — install it from https://golangci-lint.run
     cmds:
       - golangci-lint run
+
+  release:
+    desc: Tag and push the next release — triggers the release workflow (requires svu)
+    preconditions:
+      - sh: command -v svu
+        msg: svu not found — install from https://github.com/caarlos0/svu
+    cmds:
+      - git tag $(svu next)
+      - git push origin $(svu next)

--- a/cmd/sqlfmt/main.go
+++ b/cmd/sqlfmt/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rpf3/sqlfmt/internal/linter"
 )
 
+var version = "dev"
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stderr))
 }
@@ -153,12 +155,18 @@ func run(args []string, stderr io.Writer) int {
 	check := fset.Bool("check", false, "exit non-zero if any file is not formatted; write nothing")
 	warningsAsErrors := fset.Bool("warnings-as-errors", false, "exit non-zero if any lint warnings are emitted")
 	recursive := fset.Bool("recursive", false, "recurse into subdirectories when a directory argument is given")
+	showVersion := fset.Bool("version", false, "print version and exit")
 
 	if err := fset.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
 		}
 		return 1
+	}
+
+	if *showVersion {
+		fmt.Fprintln(os.Stdout, "sqlfmt "+version)
+		return 0
 	}
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
## Summary

- Adds `--version` flag to the CLI (`sqlfmt --version` prints `sqlfmt <version>`)
- Adds `.goreleaser.yaml` to cross-compile for 6 platform/arch targets and publish GitHub Releases
- Adds `.github/workflows/release.yml` triggered on `v*.*.*` tag push
- Updates `task build` to inject version from `git describe`; adds `task release` for tagging with `svu`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)