### PR TITLE
ci: ensure gh-pages branch exists before storing benchmark results

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,6 +19,16 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Ensure gh-pages branch exists
+        run: |
+          git fetch origin gh-pages 2>/dev/null || (
+            git checkout --orphan gh-pages &&
+            git rm -rf . &&
+            git commit --allow-empty -m "init: create gh-pages branch for benchmark results" &&
+            git push origin gh-pages &&
+            git checkout -
+          )
+
       - name: Run benchmarks
         run: go test -bench=. -benchmem -count=3 ./... | tee bench.txt
 


### PR DESCRIPTION
## Summary

- Fixes the "couldn't find remote ref gh-pages" failure in the benchmark CI workflow added in #126
- Adds a guard step that fetches `gh-pages` or creates an empty orphan and pushes it on first run
- Also bootstrapped the `gh-pages` branch manually so the next push to `main` succeeds immediately

## Root cause

`benchmark-action/github-action-benchmark` with `auto-push: true` pushes result JSON to `gh-pages` but cannot create the branch from scratch — it requires the remote ref to already exist.

## Fix

```yaml
- name: Ensure gh-pages branch exists
  run: |
    git fetch origin gh-pages 2>/dev/null || (
      git checkout --orphan gh-pages &&
      git rm -rf . &&
      git commit --allow-empty -m "init: create gh-pages branch for benchmark results" &&
      git push origin gh-pages &&
      git checkout -
    )
```

The `||` short-circuits on success — on every normal run the fetch completes instantly. The orphan fallback only fires if `gh-pages` is ever deleted.

## Test plan

- [x] `gh-pages` orphan branch already pushed to remote manually
- [x] Next push to `main` will exercise the guard step (fetch succeeds, no orphan needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)