### PR TITLE
feat: split UPDATE JOIN ON predicates across lines on AND

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -78,7 +78,11 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 				b.WriteString(" " + f.kw("as") + " " + jc.Alias)
 			}
 			if jc.On != nil {
-				b.WriteString("\n" + ind + ind + f.kw("on") + " " + parser.Render(jc.On))
+				terms := parser.AndTerms(jc.On)
+				b.WriteString("\n" + ind + ind + f.kw("on") + " " + parser.Render(terms[0]))
+				for _, term := range terms[1:] {
+					b.WriteString("\n" + ind + ind + f.kw("and") + " " + parser.Render(term))
+				}
 			}
 		}
 	}

--- a/internal/formatter/testdata/update.input.sql
+++ b/internal/formatter/testdata/update.input.sql
@@ -3,3 +3,4 @@ UPDATE   orders  SET  status='shipped',updated_at=now()  WHERE id=42;
 UPDATE o SET o.status='shipped' FROM orders AS o WHERE o.id=42;
 UPDATE o SET o.status='shipped' FROM orders AS o INNER JOIN customers AS c ON o.customer_id=c.id WHERE c.name='test';
 UPDATE o SET o.status='x',o.note='test' FROM orders AS o WHERE o.id=1 AND o.active=1;
+UPDATE o SET o.status='shipped' FROM orders AS o INNER JOIN customers AS c ON o.customer_id=c.id AND o.region=c.region WHERE c.name='test';

--- a/internal/formatter/testdata/update.sql
+++ b/internal/formatter/testdata/update.sql
@@ -42,3 +42,16 @@ from
 where
 	o.id = 1
 	and o.active = 1;
+
+update
+	o
+set
+	o.status = 'shipped'
+from
+	orders as o
+inner join
+	customers as c
+		on o.customer_id = c.id
+		and o.region = c.region
+where
+	c.name = 'test';


### PR DESCRIPTION
## Summary

- Fixes the UPDATE formatter to split multi-AND JOIN ON conditions across lines, one term per line, matching the existing SELECT formatter behaviour
- The `AndTerms()` split loop was already used in `format_select.go` (lines 117–121) — this change applies the exact same pattern to the equivalent block in `format_update` (`format_ddl.go`)
- Adds a new golden test case: `UPDATE … INNER JOIN … ON a=b AND c=d WHERE …`

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)