### PR TITLE
refactor: parse function calls into FunctionCallExpr

### DIFF
--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -20,11 +20,18 @@ type IdentExpr struct{ Parts []string }
 // LiteralExpr is a literal token: string, integer, float, or keyword literal.
 type LiteralExpr struct{ Token lexer.Token }
 
+// WindowSpec holds the OVER clause of a window function call.
+type WindowSpec struct {
+	PartitionBy []Expr      // PARTITION BY expressions; nil if absent
+	OrderBy     []OrderItem // ORDER BY items; nil if absent
+}
+
 // FunctionCallExpr is a function call: name(args…) or name(*).
 type FunctionCallExpr struct {
 	Name string
 	Args []Expr
-	Star bool // true for count(*)
+	Star bool        // true for count(*)
+	Over *WindowSpec // non-nil for window functions with OVER clause
 }
 
 // BinaryExpr is a binary operation: left op right (e.g. "a.id = b.id").
@@ -68,14 +75,41 @@ func Render(e Expr) string {
 	case *LiteralExpr:
 		return v.Token.Value
 	case *FunctionCallExpr:
+		var result string
 		if v.Star {
-			return v.Name + "(*)"
+			result = v.Name + "(*)"
+		} else {
+			args := make([]string, len(v.Args))
+			for i, a := range v.Args {
+				args[i] = Render(a)
+			}
+			result = v.Name + "(" + strings.Join(args, ", ") + ")"
 		}
-		args := make([]string, len(v.Args))
-		for i, a := range v.Args {
-			args[i] = Render(a)
+		if v.Over != nil {
+			var overParts []string
+			if len(v.Over.PartitionBy) > 0 {
+				parts := make([]string, len(v.Over.PartitionBy))
+				for i, e := range v.Over.PartitionBy {
+					parts[i] = Render(e)
+				}
+				overParts = append(overParts, "partition by "+strings.Join(parts, ", "))
+			}
+			if len(v.Over.OrderBy) > 0 {
+				items := make([]string, len(v.Over.OrderBy))
+				for i, ob := range v.Over.OrderBy {
+					s := Render(ob.Value)
+					if ob.Direction == DirectionAsc {
+						s += " asc"
+					} else if ob.Direction == DirectionDesc {
+						s += " desc"
+					}
+					items[i] = s
+				}
+				overParts = append(overParts, "order by "+strings.Join(items, ", "))
+			}
+			result += " over (" + strings.Join(overParts, " ") + ")"
 		}
-		return v.Name + "(" + strings.Join(args, ", ") + ")"
+		return result
 	case *BinaryExpr:
 		return Render(v.Left) + " " + v.Op + " " + Render(v.Right)
 	case *ParenExpr:
@@ -106,6 +140,14 @@ func Walk(e Expr, fn func(Expr)) {
 	case *FunctionCallExpr:
 		for _, a := range v.Args {
 			Walk(a, fn)
+		}
+		if v.Over != nil {
+			for _, e := range v.Over.PartitionBy {
+				Walk(e, fn)
+			}
+			for _, ob := range v.Over.OrderBy {
+				Walk(ob.Value, fn)
+			}
 		}
 	case *BinaryExpr:
 		Walk(v.Left, fn)

--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -69,16 +69,15 @@ func needsSelectSpace(prev, cur lexer.TokenType) bool {
 	return true
 }
 
-// parseExpr wraps parseExprRaw into a RawExpr, providing a zero-behaviour-change
-// bridge from string-based parsing to the Expr interface. Callers that do not
-// need AND-splitting should use this instead of parseExprRaw directly.
+// parseExpr parses a single expression, lifting top-level function calls into
+// *FunctionCallExpr nodes when possible. Falls back to *RawExpr otherwise.
+// Callers that do not need AND-splitting should use this instead of parseExprRaw directly.
 func (p *parser) parseExpr(stopFn func() bool) Expr {
-	text, _ := p.parseExprRaw(stopFn)
-	return &RawExpr{Text: text}
+	return p.parseExprNode(stopFn)
 }
 
 // parseAndChain splits an expression on top-level AND tokens, returning an
-// AndChain when more than one term is found, or a single RawExpr otherwise.
+// AndChain when more than one term is found, or a single node otherwise.
 // This enables the formatter to emit multi-line WHERE/HAVING/ON predicates
 // (#101) while keeping Render(result) == parseExprRaw(same stopFn) for all
 // inputs — golden tests remain byte-identical.
@@ -86,10 +85,10 @@ func (p *parser) parseAndChain(stopFn func() bool) Expr {
 	var terms []Expr
 	for {
 		// Read one AND-term: stop at AND (at depth 0) or at the caller's stop.
-		text, _ := p.parseExprRaw(func() bool {
+		term := p.parseExprNode(func() bool {
 			return p.curKeyword("AND") || stopFn()
 		})
-		terms = append(terms, &RawExpr{Text: text})
+		terms = append(terms, term)
 
 		// If the caller's stop condition fired (not AND), we're done.
 		if !p.curKeyword("AND") {
@@ -102,6 +101,119 @@ func (p *parser) parseAndChain(stopFn func() bool) Expr {
 		return terms[0]
 	}
 	return &AndChain{Terms: terms}
+}
+
+// parseExprNode wraps parseExprRaw but lifts top-level function calls into
+// *FunctionCallExpr nodes. When the expression does not start with a function
+// call, or when the function call is only part of a larger expression (e.g.
+// count(*) + 1), it falls back to *RawExpr — preserving the Render invariant.
+func (p *parser) parseExprNode(stopFn func() bool) Expr {
+	if p.cur.Type == lexer.Ident && p.peek.Type == lexer.LParen {
+		fn := p.parseFunctionCall()
+		// If the function call consumed the entire expression, return it structured.
+		if p.cur.Type == lexer.EOF || p.cur.Type == lexer.RParen || stopFn() {
+			return fn
+		}
+		// More tokens follow — render fn back to string and accumulate the rest.
+		rest, _ := p.parseExprRaw(stopFn)
+		return &RawExpr{Text: Render(fn) + " " + rest}
+	}
+	text, _ := p.parseExprRaw(stopFn)
+	return &RawExpr{Text: text}
+}
+
+// parseFunctionCall parses a function call starting at the current Ident token.
+// On entry: p.cur is the function name Ident; p.peek is LParen.
+// On exit: p.cur is positioned after the closing RParen (and OVER clause if present).
+func (p *parser) parseFunctionCall() *FunctionCallExpr {
+	name := exprToken(p.cur) // normalize (lowercase built-in names)
+	p.advance()              // consume ident
+	p.advance()              // consume (
+
+	fn := &FunctionCallExpr{Name: name}
+
+	if p.cur.Type == lexer.Star {
+		fn.Star = true
+		p.advance() // consume *
+		p.advance() // consume )
+	} else {
+		for p.cur.Type != lexer.RParen && p.cur.Type != lexer.EOF {
+			arg := p.parseExprNode(func() bool {
+				return p.cur.Type == lexer.Comma || p.cur.Type == lexer.RParen
+			})
+			fn.Args = append(fn.Args, arg)
+			if p.cur.Type == lexer.Comma {
+				p.advance() // consume ,
+			}
+		}
+		if p.cur.Type == lexer.RParen {
+			p.advance() // consume )
+		}
+	}
+
+	// Window function: check for OVER (
+	if p.curKeyword("OVER") && p.peek.Type == lexer.LParen {
+		p.advance() // consume OVER
+		fn.Over = p.parseWindowSpec()
+	}
+
+	return fn
+}
+
+// parseWindowSpec parses the parenthesised OVER clause of a window function.
+// On entry: p.cur is LParen (the opening paren of the OVER clause).
+// On exit: p.cur is positioned after the closing RParen.
+func (p *parser) parseWindowSpec() *WindowSpec {
+	p.advance() // consume (
+	ws := &WindowSpec{}
+
+	if p.curKeyword("PARTITION") {
+		p.advance() // consume PARTITION
+		p.advance() // consume BY
+		for {
+			expr := p.parseExprNode(func() bool {
+				return p.cur.Type == lexer.Comma ||
+					p.curKeyword("ORDER") ||
+					p.cur.Type == lexer.RParen
+			})
+			ws.PartitionBy = append(ws.PartitionBy, expr)
+			if p.cur.Type == lexer.Comma {
+				p.advance()
+			} else {
+				break
+			}
+		}
+	}
+
+	if p.curKeyword("ORDER") {
+		p.advance() // consume ORDER
+		p.advance() // consume BY
+		for {
+			val := p.parseExprNode(func() bool {
+				return p.curKeyword("ASC") || p.curKeyword("DESC") ||
+					p.cur.Type == lexer.Comma || p.cur.Type == lexer.RParen
+			})
+			dir := DirectionNone
+			if p.curKeyword("ASC") {
+				dir = DirectionAsc
+				p.advance()
+			} else if p.curKeyword("DESC") {
+				dir = DirectionDesc
+				p.advance()
+			}
+			ws.OrderBy = append(ws.OrderBy, OrderItem{Value: val, Direction: dir})
+			if p.cur.Type == lexer.Comma {
+				p.advance()
+			} else {
+				break
+			}
+		}
+	}
+
+	if p.cur.Type == lexer.RParen {
+		p.advance() // consume )
+	}
+	return ws
 }
 
 // parseExprRaw reads tokens into a normalised expression string, tracking

--- a/internal/parser/parse_expr_test.go
+++ b/internal/parser/parse_expr_test.go
@@ -95,7 +95,8 @@ func TestParseAndChain_NestedParens(t *testing.T) {
 
 // TestParseAndChain_RenderIdentity verifies the key invariant:
 // Render(parseAndChain(…)) == text produced by parseExprRaw for all inputs.
-// We test this with a multi-term expression and a nested paren expression.
+// We test this with a multi-term expression and a nested paren expression,
+// and with function calls appearing as AND terms.
 func TestParseAndChain_RenderIdentity(t *testing.T) {
 	cases := []string{
 		"a = 1",
@@ -103,6 +104,7 @@ func TestParseAndChain_RenderIdentity(t *testing.T) {
 		"a = 1 AND b = 2 AND c = 3",
 		"(a = 1 AND b = 2)",
 		"t.id = s.id AND t.type = 'x'",
+		"count(*) > 0 AND sum(t.v) > 100",
 	}
 	for _, sql := range cases {
 		// Obtain the reference string via parseExprRaw.
@@ -116,5 +118,202 @@ func TestParseAndChain_RenderIdentity(t *testing.T) {
 		if got != want {
 			t.Errorf("sql=%q: Render=%q, want=%q", sql, got, want)
 		}
+	}
+}
+
+// ─── parseFunctionCall / parseWindowSpec tests ────────────────────────────────
+
+// TestParseFunctionCall_Star verifies that count(*) produces a FunctionCallExpr
+// with Star=true and renders back to "count(*)".
+func TestParseFunctionCall_Star(t *testing.T) {
+	p := newTestParser("count(*)")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if fn.Name != "count" {
+		t.Errorf("Name: got %q, want %q", fn.Name, "count")
+	}
+	if !fn.Star {
+		t.Error("Star: expected true")
+	}
+	if fn.Over != nil {
+		t.Error("Over: expected nil")
+	}
+	if got := Render(e); got != "count(*)" {
+		t.Errorf("Render: got %q, want %q", got, "count(*)")
+	}
+}
+
+// TestParseFunctionCall_NoArgs verifies that now() produces a FunctionCallExpr
+// with no Args and renders back to "now()".
+func TestParseFunctionCall_NoArgs(t *testing.T) {
+	p := newTestParser("now()")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if fn.Name != "now" {
+		t.Errorf("Name: got %q, want %q", fn.Name, "now")
+	}
+	if len(fn.Args) != 0 {
+		t.Errorf("Args: got %d, want 0", len(fn.Args))
+	}
+	if got := Render(e); got != "now()" {
+		t.Errorf("Render: got %q, want %q", got, "now()")
+	}
+}
+
+// TestParseFunctionCall_SingleArg verifies that sum(t.total) produces a
+// FunctionCallExpr with one arg and renders back correctly.
+func TestParseFunctionCall_SingleArg(t *testing.T) {
+	p := newTestParser("sum(t.total)")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if fn.Name != "sum" {
+		t.Errorf("Name: got %q, want %q", fn.Name, "sum")
+	}
+	if len(fn.Args) != 1 {
+		t.Fatalf("Args: got %d, want 1", len(fn.Args))
+	}
+	if got := Render(fn.Args[0]); got != "t.total" {
+		t.Errorf("Args[0]: got %q, want %q", got, "t.total")
+	}
+	if got := Render(e); got != "sum(t.total)" {
+		t.Errorf("Render: got %q, want %q", got, "sum(t.total)")
+	}
+}
+
+// TestParseFunctionCall_MultiArg verifies that coalesce(t.a, 'x') produces a
+// FunctionCallExpr with two args.
+func TestParseFunctionCall_MultiArg(t *testing.T) {
+	p := newTestParser("coalesce(t.a, 'x')")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if fn.Name != "coalesce" {
+		t.Errorf("Name: got %q, want %q", fn.Name, "coalesce")
+	}
+	if len(fn.Args) != 2 {
+		t.Fatalf("Args: got %d, want 2", len(fn.Args))
+	}
+	if got := Render(e); got != "coalesce(t.a, 'x')" {
+		t.Errorf("Render: got %q, want %q", got, "coalesce(t.a, 'x')")
+	}
+}
+
+// TestParseFunctionCall_Nested verifies that coalesce(nullif(t.v, ”), 'x')
+// lifts the inner nullif call into a nested *FunctionCallExpr.
+func TestParseFunctionCall_Nested(t *testing.T) {
+	p := newTestParser("coalesce(nullif(t.v, ''), 'x')")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if len(fn.Args) != 2 {
+		t.Fatalf("Args: got %d, want 2", len(fn.Args))
+	}
+	inner, ok := fn.Args[0].(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("Args[0]: expected *FunctionCallExpr, got %T", fn.Args[0])
+	}
+	if inner.Name != "nullif" {
+		t.Errorf("inner Name: got %q, want %q", inner.Name, "nullif")
+	}
+	if got := Render(e); got != "coalesce(nullif(t.v, ''), 'x')" {
+		t.Errorf("Render: got %q, want %q", got, "coalesce(nullif(t.v, ''), 'x')")
+	}
+}
+
+// TestParseWindowFunc_OrderOnly verifies that row_number() OVER (ORDER BY t.id DESC)
+// produces a FunctionCallExpr with an Over clause with one OrderBy item.
+func TestParseWindowFunc_OrderOnly(t *testing.T) {
+	p := newTestParser("row_number() over (order by t.id desc)")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if fn.Name != "row_number" {
+		t.Errorf("Name: got %q, want %q", fn.Name, "row_number")
+	}
+	if fn.Over == nil {
+		t.Fatal("Over: expected non-nil")
+	}
+	if len(fn.Over.PartitionBy) != 0 {
+		t.Errorf("PartitionBy: got %d items, want 0", len(fn.Over.PartitionBy))
+	}
+	if len(fn.Over.OrderBy) != 1 {
+		t.Fatalf("OrderBy: got %d items, want 1", len(fn.Over.OrderBy))
+	}
+	if got := Render(fn.Over.OrderBy[0].Value); got != "t.id" {
+		t.Errorf("OrderBy[0].Value: got %q, want %q", got, "t.id")
+	}
+	if fn.Over.OrderBy[0].Direction != DirectionDesc {
+		t.Errorf("OrderBy[0].Direction: got %v, want DirectionDesc", fn.Over.OrderBy[0].Direction)
+	}
+	want := "row_number() over (order by t.id desc)"
+	if got := Render(e); got != want {
+		t.Errorf("Render: got %q, want %q", got, want)
+	}
+}
+
+// TestParseWindowFunc_PartitionAndOrder verifies a full window spec with both
+// PARTITION BY and ORDER BY clauses.
+func TestParseWindowFunc_PartitionAndOrder(t *testing.T) {
+	p := newTestParser("sum(t.v) over (partition by t.cid order by t.date asc)")
+	e := p.parseExpr(alwaysFalse)
+
+	fn, ok := e.(*FunctionCallExpr)
+	if !ok {
+		t.Fatalf("expected *FunctionCallExpr, got %T", e)
+	}
+	if fn.Over == nil {
+		t.Fatal("Over: expected non-nil")
+	}
+	if len(fn.Over.PartitionBy) != 1 {
+		t.Fatalf("PartitionBy: got %d items, want 1", len(fn.Over.PartitionBy))
+	}
+	if got := Render(fn.Over.PartitionBy[0]); got != "t.cid" {
+		t.Errorf("PartitionBy[0]: got %q, want %q", got, "t.cid")
+	}
+	if len(fn.Over.OrderBy) != 1 {
+		t.Fatalf("OrderBy: got %d items, want 1", len(fn.Over.OrderBy))
+	}
+	if fn.Over.OrderBy[0].Direction != DirectionAsc {
+		t.Errorf("OrderBy[0].Direction: got %v, want DirectionAsc", fn.Over.OrderBy[0].Direction)
+	}
+	want := "sum(t.v) over (partition by t.cid order by t.date asc)"
+	if got := Render(e); got != want {
+		t.Errorf("Render: got %q, want %q", got, want)
+	}
+}
+
+// TestParseExpr_FuncCallNotAtStart verifies that a function call embedded
+// mid-expression (not at the start) remains a *RawExpr.
+func TestParseExpr_FuncCallNotAtStart(t *testing.T) {
+	p := newTestParser("t.id = count(*)")
+	e := p.parseExpr(alwaysFalse)
+
+	_, isRaw := e.(*RawExpr)
+	if !isRaw {
+		t.Fatalf("expected *RawExpr for mid-expression function call, got %T", e)
+	}
+	if got := Render(e); got != "t.id = count(*)" {
+		t.Errorf("Render: got %q, want %q", got, "t.id = count(*)")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `WindowSpec` struct and `Over *WindowSpec` field to `FunctionCallExpr` in `expr.go`; updates `Render()` and `Walk()` to handle the OVER clause
- Introduces `parseExprNode()`, `parseFunctionCall()`, and `parseWindowSpec()` in `parse_expr.go`; updates `parseExpr()` and `parseAndChain()` to use the new node-lifting path
- Adds 8 new unit tests in `parse_expr_test.go` covering all function call shapes and the render invariant; all formatter golden tests pass unchanged

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)