### PR TITLE
feat: lint window function ORDER BY direction

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,7 @@ const (
 	RuleUnaliasedTable              = "unaliased-table"
 	RuleMergeInsertColumnList       = "merge-insert-column-list"
 	RuleMergeUpdateWithoutCondition = "merge-update-without-condition"
+	RuleWindowOrderDirection        = "window-order-direction"
 )
 
 // knownRules is the set of valid lint rule names for config validation.
@@ -81,6 +82,7 @@ var knownRules = map[string]bool{
 	RuleUnaliasedTable:              true,
 	RuleMergeInsertColumnList:       true,
 	RuleMergeUpdateWithoutCondition: true,
+	RuleWindowOrderDirection:        true,
 }
 
 // Config holds all formatting and linting options for sqlfmt.

--- a/internal/linter/lint_select.go
+++ b/internal/linter/lint_select.go
@@ -31,6 +31,23 @@ func (l *linter) checkSelectStmt(s *parser.SelectStmt) {
 		}
 	}
 
+	// #32 window-order-direction
+	for _, col := range s.Columns {
+		parser.Walk(col.Value, func(e parser.Expr) {
+			fn, ok := e.(*parser.FunctionCallExpr)
+			if !ok || fn.Over == nil {
+				return
+			}
+			for _, ob := range fn.Over.OrderBy {
+				if ob.Direction == parser.DirectionNone {
+					l.warn(config.RuleWindowOrderDirection,
+						fmt.Sprintf("window function %s has ORDER BY column %q with no explicit direction; specify ASC or DESC",
+							fn.Name, parser.Render(ob.Value)))
+				}
+			}
+		})
+	}
+
 	// #34 alias-without-as (FROM source)
 	if s.From.Alias != "" && !s.From.AliasExplicit {
 		name := s.From.Name

--- a/internal/linter/lint_select_test.go
+++ b/internal/linter/lint_select_test.go
@@ -269,6 +269,61 @@ func TestLintUnaliasedTable(t *testing.T) {
 	})
 }
 
+func TestLintWindowOrderDirection(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantRule string
+	}{
+		{
+			name:     "no direction warns",
+			input:    `select row_number() over (order by created_at) as rn from events as e;`,
+			wantRule: config.RuleWindowOrderDirection,
+		},
+		{
+			name:     "explicit desc is clean",
+			input:    `select row_number() over (order by created_at desc) as rn from events as e;`,
+			wantRule: "",
+		},
+		{
+			name:     "explicit asc is clean",
+			input:    `select rank() over (order by score asc) as rnk from events as e;`,
+			wantRule: "",
+		},
+		{
+			name:     "partition by with no order direction warns",
+			input:    `select sum(amount) over (partition by customer_id order by created_at) as running_total from orders as o;`,
+			wantRule: config.RuleWindowOrderDirection,
+		},
+		{
+			name:     "partition by with explicit direction is clean",
+			input:    `select sum(amount) over (partition by customer_id order by created_at asc) as running_total from orders as o;`,
+			wantRule: "",
+		},
+		{
+			name:     "window function with no over clause is clean",
+			input:    `select count(*) from orders as o;`,
+			wantRule: "",
+		},
+		{
+			name:     "plain select with no window function is clean",
+			input:    `select id from orders as o order by created_at asc;`,
+			wantRule: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkRule(t, tt.input, tt.wantRule)
+		})
+	}
+
+	t.Run("off suppresses warning", func(t *testing.T) {
+		checkRuleOff(t,
+			`select row_number() over (order by created_at) as rn from events as e;`,
+			config.RuleWindowOrderDirection)
+	})
+}
+
 func TestLintSelectStar(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Adds `RuleWindowOrderDirection = "window-order-direction"` to `config.go` and `knownRules`
- Implements the check in `lint_select.go`: walks each `SelectItem.Value` with `parser.Walk()`, finds `*FunctionCallExpr` nodes with a non-nil `Over` clause, and warns for any ORDER BY item with `DirectionNone`
- Adds 7 subtests + `off suppresses warning` in `lint_select_test.go`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)