### PR TITLE
feat: UNION / INTERSECT / EXCEPT set operators

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -154,6 +154,14 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		f.writeExprPred(&b, s.Having)
 	}
 
+	// Set operations: UNION [ALL] / INTERSECT / EXCEPT
+	for _, setOp := range s.SetOps {
+		b.WriteString("\n" + f.kw(setOpKeyword(setOp.Op)))
+		branch := f.formatSelectStmt(setOp.Select)
+		branch = strings.TrimSuffix(branch, ";")
+		b.WriteString("\n" + branch)
+	}
+
 	// ORDER BY
 	if len(s.OrderBy) > 0 {
 		b.WriteString("\n" + f.kw("order by"))
@@ -191,6 +199,21 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 
 	b.WriteString(";")
 	return b.String()
+}
+
+// setOpKeyword returns the canonical lowercase keyword phrase for a SetOpType.
+func setOpKeyword(op parser.SetOpType) string {
+	switch op {
+	case parser.SetOpUnion:
+		return "union"
+	case parser.SetOpUnionAll:
+		return "union all"
+	case parser.SetOpIntersect:
+		return "intersect"
+	case parser.SetOpExcept:
+		return "except"
+	}
+	return "union"
 }
 
 // joinKeyword returns the canonical lowercase keyword phrase for a JoinType.

--- a/internal/formatter/testdata/union.input.sql
+++ b/internal/formatter/testdata/union.input.sql
@@ -1,0 +1,26 @@
+-- simple UNION ALL
+select id, name from orders where status = 'active' union all select id, name from archived_orders where status = 'active';
+
+-- simple UNION (distinct)
+select t.customer_id from orders as t union select t.customer_id from archived_orders as t;
+
+-- INTERSECT
+select t.customer_id from orders as t intersect select t.customer_id from preferred_customers as t;
+
+-- EXCEPT
+select t.customer_id from all_customers as t except select t.customer_id from churned_customers as t;
+
+-- three-branch UNION ALL
+select id, name, status from orders union all select id, name, status from archived_orders union all select id, name, status from deleted_orders;
+
+-- UNION ALL with ORDER BY on the whole set (ORDER BY applies to the combined result)
+select id, name from orders where status = 'active' union all select id, name from archived_orders where status = 'active' order by name asc;
+
+-- UNION ALL with complex branches (GROUP BY, HAVING)
+select t.region, count(*) as order_count from orders as t group by t.region having count(*) > 10 union all select t.region, count(*) as order_count from archived_orders as t group by t.region having count(*) > 10;
+
+-- UNION ALL inside a CTE
+with combined as (select id, status from orders union all select id, status from archived_orders) select c.id, c.status from combined as c where c.status = 'active';
+
+-- UNION ALL inside a CTE with ORDER BY on outer query
+with combined as (select id, name from orders union all select id, name from archived_orders) select c.id, c.name from combined as c order by c.name asc;

--- a/internal/formatter/testdata/union.sql
+++ b/internal/formatter/testdata/union.sql
@@ -1,0 +1,148 @@
+select
+	id
+,	name
+from
+	orders
+where
+	status = 'active'
+union all
+select
+	id
+,	name
+from
+	archived_orders
+where
+	status = 'active';
+
+select
+	t.customer_id
+from
+	orders as t
+union
+select
+	t.customer_id
+from
+	archived_orders as t;
+
+select
+	t.customer_id
+from
+	orders as t
+intersect
+select
+	t.customer_id
+from
+	preferred_customers as t;
+
+select
+	t.customer_id
+from
+	all_customers as t
+except
+select
+	t.customer_id
+from
+	churned_customers as t;
+
+select
+	id
+,	name
+,	status
+from
+	orders
+union all
+select
+	id
+,	name
+,	status
+from
+	archived_orders
+union all
+select
+	id
+,	name
+,	status
+from
+	deleted_orders;
+
+select
+	id
+,	name
+from
+	orders
+where
+	status = 'active'
+union all
+select
+	id
+,	name
+from
+	archived_orders
+where
+	status = 'active'
+order by
+	name asc;
+
+select
+	t.region
+,	count(*) as order_count
+from
+	orders as t
+group by
+	t.region
+having
+	count(*) > 10
+union all
+select
+	t.region
+,	count(*) as order_count
+from
+	archived_orders as t
+group by
+	t.region
+having
+	count(*) > 10;
+
+with combined as
+(
+	select
+		id
+	,	status
+	from
+		orders
+	union all
+	select
+		id
+	,	status
+	from
+		archived_orders
+)
+select
+	c.id
+,	c.status
+from
+	combined as c
+where
+	c.status = 'active';
+
+with combined as
+(
+	select
+		id
+	,	name
+	from
+		orders
+	union all
+	select
+		id
+	,	name
+	from
+		archived_orders
+)
+select
+	c.id
+,	c.name
+from
+	combined as c
+order by
+	c.name asc;

--- a/internal/linter/lint_schema.go
+++ b/internal/linter/lint_schema.go
@@ -88,4 +88,7 @@ func (l *linter) checkSchemaSelect(s *parser.SelectStmt) {
 	if s.WhereSubq != nil {
 		l.checkSchemaSelect(s.WhereSubq)
 	}
+	for _, setOp := range s.SetOps {
+		l.checkSchemaSelect(setOp.Select)
+	}
 }

--- a/internal/linter/lint_select.go
+++ b/internal/linter/lint_select.go
@@ -101,11 +101,14 @@ func (l *linter) checkSelectStmt(s *parser.SelectStmt) {
 		}
 	}
 
-	// Recurse into subqueries.
+	// Recurse into subqueries and set-operation branches.
 	if s.From.Subquery != nil {
 		l.checkSelectStmt(s.From.Subquery)
 	}
 	if s.WhereSubq != nil {
 		l.checkSelectStmt(s.WhereSubq)
+	}
+	for _, setOp := range s.SetOps {
+		l.checkSelectStmt(setOp.Select)
 	}
 }

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -244,6 +244,22 @@ func (*MergeStmt) statementNode() {}
 
 // ─── SELECT statement ─────────────────────────────────────────────────────────
 
+// SetOpType identifies the kind of set operation joining two SELECT branches.
+type SetOpType int
+
+const (
+	SetOpUnion     SetOpType = iota // UNION (distinct)
+	SetOpUnionAll                   // UNION ALL
+	SetOpIntersect                  // INTERSECT
+	SetOpExcept                     // EXCEPT
+)
+
+// SetOp pairs a set operator with the right-hand SELECT branch.
+type SetOp struct {
+	Op     SetOpType
+	Select *SelectStmt
+}
+
 // SelectItem is one entry in a SELECT list.
 type SelectItem struct {
 	Value Expr   // expression; "*" for SELECT *
@@ -309,7 +325,8 @@ type SelectStmt struct {
 	WhereSubq     *SelectStmt  // structured WHERE subquery; nil if Where is set
 	GroupBy       []Expr       // GROUP BY expressions; nil if absent
 	Having        Expr         // HAVING predicate; nil if absent
-	OrderBy       []OrderItem  // ORDER BY items; nil if absent
+	SetOps        []SetOp      // UNION/INTERSECT/EXCEPT branches; nil for a plain SELECT
+	OrderBy       []OrderItem  // ORDER BY items; nil if absent; applies to whole compound query when SetOps non-nil
 	Offset        string       // n from OFFSET n ROWS; empty if absent
 	OffsetHasRows bool         // true when ROWS or ROW keyword followed the offset value
 	Fetch         string       // n from FETCH NEXT n ROWS ONLY; empty if absent

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -6,11 +6,18 @@ import (
 	"github.com/rpf3/sqlfmt/internal/lexer"
 )
 
-// parseSelectCore parses the body of a SELECT statement, consuming the SELECT
-// keyword through all clauses. It does NOT consume a trailing semicolon or
-// closing parenthesis — the caller handles those. It is used both for
-// top-level SELECTs (via parseSelect) and for subqueries.
-func (p *parser) parseSelectCore() (*SelectStmt, error) {
+// isSetOpKeyword reports whether the current token starts a set operator
+// (UNION, INTERSECT, or EXCEPT).
+func (p *parser) isSetOpKeyword() bool {
+	return p.curKeyword("UNION") || p.curKeyword("INTERSECT") || p.curKeyword("EXCEPT")
+}
+
+// parseSelectBranch parses one SELECT branch: SELECT [DISTINCT] cols FROM …
+// [JOINs] [WHERE] [GROUP BY] [HAVING]. It stops before ORDER BY, OFFSET,
+// FETCH, LIMIT, set operators (UNION/INTERSECT/EXCEPT), semicolons, and
+// closing parentheses. The ORDER BY and pagination clauses are parsed by the
+// enclosing parseSelectCore so they apply to the whole compound query.
+func (p *parser) parseSelectBranch() (*SelectStmt, error) {
 	p.advance() // consume SELECT
 
 	stmt := &SelectStmt{}
@@ -50,6 +57,7 @@ func (p *parser) parseSelectCore() (*SelectStmt, error) {
 				p.curKeyword("GROUP") || p.curKeyword("HAVING") ||
 				p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
 				p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+				p.isSetOpKeyword() ||
 				p.curIs(lexer.Semicolon) || p.curIs(lexer.RParen)
 		}
 		whereExpr := p.parseAndChain(stopFn)
@@ -84,10 +92,58 @@ func (p *parser) parseSelectCore() (*SelectStmt, error) {
 		stmt.Having = p.parseAndChain(func() bool {
 			return p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
 				p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+				p.isSetOpKeyword() ||
 				p.curIs(lexer.Semicolon) || p.curIs(lexer.RParen)
 		})
 	}
 
+	return stmt, nil
+}
+
+// parseSelectCore parses a full SELECT statement (possibly compound via set
+// operators) through all clauses including ORDER BY and pagination. It does
+// NOT consume a trailing semicolon or closing parenthesis — the caller
+// handles those. It is used both for top-level SELECTs and for subqueries.
+func (p *parser) parseSelectCore() (*SelectStmt, error) {
+	stmt, err := p.parseSelectBranch()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set operators: UNION [ALL] / INTERSECT / EXCEPT
+	for p.isSetOpKeyword() {
+		var opType SetOpType
+		switch {
+		case p.curKeyword("UNION"):
+			p.advance() // consume UNION
+			if p.curKeyword("ALL") {
+				p.advance() // consume ALL
+				opType = SetOpUnionAll
+			} else {
+				opType = SetOpUnion
+			}
+		case p.curKeyword("INTERSECT"):
+			p.advance()
+			opType = SetOpIntersect
+		default: // EXCEPT
+			p.advance()
+			opType = SetOpExcept
+		}
+
+		if !p.curKeyword("SELECT") {
+			return nil, fmt.Errorf(
+				"expected SELECT after set operator at %d:%d, got %s %q",
+				p.cur.Line, p.cur.Column, p.cur.Type, p.cur.Value,
+			)
+		}
+		branch, err := p.parseSelectBranch()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SetOps = append(stmt.SetOps, SetOp{Op: opType, Select: branch})
+	}
+
+	// ORDER BY / pagination — apply to the whole compound query (or plain SELECT).
 	if p.curKeyword("ORDER") && p.peekKeyword("BY") {
 		p.advance() // consume ORDER
 		p.advance() // consume BY
@@ -255,6 +311,7 @@ func (p *parser) parseGroupByList() ([]Expr, error) {
 			return p.curIs(lexer.Comma) || p.curKeyword("HAVING") ||
 				p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
 				p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+				p.isSetOpKeyword() ||
 				p.curIs(lexer.Semicolon)
 		})
 		exprs = append(exprs, expr)
@@ -382,7 +439,8 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 					p.curKeyword("WHERE") || p.curKeyword("GROUP") ||
 					p.curKeyword("HAVING") || p.curKeyword("ORDER") ||
 					p.curKeyword("OFFSET") || p.curKeyword("FETCH") ||
-					p.curKeyword("LIMIT") || p.curIs(lexer.Semicolon)
+					p.curKeyword("LIMIT") || p.isSetOpKeyword() ||
+					p.curIs(lexer.Semicolon)
 			})
 		} else if p.curKeyword("USING") {
 			p.advance()


### PR DESCRIPTION
## Summary

- Parse and format compound SELECT statements joined by `UNION [ALL]`, `INTERSECT`, and `EXCEPT`
- All existing golden tests pass unchanged — no formatter behaviour changed for plain SELECTs
- Lint rules (`missing-schema-name`, `select-star`, `unaliased-table`, etc.) recurse into every branch of a compound query

## Implementation notes

**AST**: `SetOpType` enum + `SetOp{Op, Select}` struct + `SelectStmt.SetOps []SetOp`. The root `SelectStmt`'s existing `OrderBy`/`Offset`/`Fetch`/`Limit` fields hold the compound query's final pagination — SQL semantics require these to apply to the entire combined result, not the last branch alone.

**Parser**: `parseSelectCore` is split into two layers. `parseSelectBranch` parses one `SELECT` through `HAVING`, stopping before set operators and `ORDER BY`. `parseSelectCore` chains branches in a loop, then parses `ORDER BY`/pagination once on the root. All expression `stopFn`s in `WHERE`, `HAVING`, `GROUP BY`, and `JOIN ON` are extended to stop at `UNION`/`INTERSECT`/`EXCEPT`. `UNION` inside CTE bodies falls out correctly: the CTE parser calls `parseSelectCore` on the body, which chains branches before the closing `)` is consumed.

**Formatter**: After `HAVING`, each `SetOp` is emitted as `\n<operator>\n<branch>`. The branch is formatted by the existing `formatSelectStmt` with its trailing semicolon stripped. `indentCTE`/`indentSubquery` require no changes — they call `formatSelectStmt` on the whole compound node and prefix every output line, so `union all` operators inside CTE bodies are indented correctly for free.

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] `task fmt && task vet && task lint` — clean
- [ ] `TestFormatGolden/union` — covers simple UNION ALL, UNION, INTERSECT, EXCEPT, three-branch UNION ALL, ORDER BY on compound query, GROUP BY/HAVING per branch, UNION inside CTE
- [ ] `TestFormatIdempotent` — auto-covers the new `union.sql` golden file

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)