### PR TITLE
feat: parse and format RECURSIVE CTEs and NATURAL JOIN

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -73,7 +73,11 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 	// WITH clause (CTEs)
 	for i, cte := range s.CTEs {
 		if i == 0 {
-			b.WriteString(f.kw("with") + " " + f.ident(cte.Name) + " " + f.kw("as"))
+			withKw := f.kw("with")
+			if s.Recursive {
+				withKw = f.kw("with recursive")
+			}
+			b.WriteString(withKw + " " + f.ident(cte.Name) + " " + f.kw("as"))
 		} else if f.cfg.CommaStyle == config.CommaTrailing {
 			b.WriteString(f.ident(cte.Name) + " " + f.kw("as"))
 		} else {
@@ -250,6 +254,12 @@ func joinKeyword(jt parser.JoinType) string {
 		return "full outer join"
 	case parser.JoinCross:
 		return "cross join"
+	case parser.JoinNatural:
+		return "natural join"
+	case parser.JoinNaturalLeft:
+		return "natural left join"
+	case parser.JoinNaturalRight:
+		return "natural right join"
 	}
 	return "join"
 }

--- a/internal/formatter/testdata/natural-join.input.sql
+++ b/internal/formatter/testdata/natural-join.input.sql
@@ -1,0 +1,4 @@
+SELECT e.name, d.name FROM employees AS e NATURAL JOIN departments AS d;
+SELECT e.name, d.name FROM employees AS e NATURAL LEFT JOIN departments AS d;
+SELECT e.name, d.name FROM employees AS e NATURAL RIGHT JOIN departments AS d;
+SELECT e.name, d.name FROM employees AS e NATURAL LEFT OUTER JOIN departments AS d;

--- a/internal/formatter/testdata/natural-join.sql
+++ b/internal/formatter/testdata/natural-join.sql
@@ -1,0 +1,31 @@
+select
+	e.name
+,	d.name
+from
+	employees as e
+natural join
+	departments as d;
+
+select
+	e.name
+,	d.name
+from
+	employees as e
+natural left join
+	departments as d;
+
+select
+	e.name
+,	d.name
+from
+	employees as e
+natural right join
+	departments as d;
+
+select
+	e.name
+,	d.name
+from
+	employees as e
+natural left join
+	departments as d;

--- a/internal/formatter/testdata/recursive-cte.input.sql
+++ b/internal/formatter/testdata/recursive-cte.input.sql
@@ -1,0 +1,2 @@
+WITH RECURSIVE subordinates AS (SELECT id, manager_id, name FROM employees WHERE manager_id IS NULL UNION ALL SELECT e.id, e.manager_id, e.name FROM employees AS e INNER JOIN subordinates AS s ON s.id = e.manager_id) SELECT id, name FROM subordinates;
+WITH RECURSIVE ancestors AS (SELECT id, parent_id, name FROM nodes WHERE id = 1 UNION ALL SELECT n.id, n.parent_id, n.name FROM nodes AS n INNER JOIN ancestors AS a ON a.id = n.parent_id) SELECT id, name FROM ancestors;

--- a/internal/formatter/testdata/recursive-cte.sql
+++ b/internal/formatter/testdata/recursive-cte.sql
@@ -1,0 +1,53 @@
+with recursive subordinates as
+(
+	select
+		id
+	,	manager_id
+	,	name
+	from
+		employees
+	where
+		manager_id is null
+	union all
+	select
+		e.id
+	,	e.manager_id
+	,	e.name
+	from
+		employees as e
+	inner join
+		subordinates as s
+			on s.id = e.manager_id
+)
+select
+	id
+,	name
+from
+	subordinates;
+
+with recursive ancestors as
+(
+	select
+		id
+	,	parent_id
+	,	name
+	from
+		nodes
+	where
+		id = 1
+	union all
+	select
+		n.id
+	,	n.parent_id
+	,	n.name
+	from
+		nodes as n
+	inner join
+		ancestors as a
+			on a.id = n.parent_id
+)
+select
+	id
+,	name
+from
+	ancestors;

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -377,11 +377,14 @@ type SelectItem struct {
 type JoinType int
 
 const (
-	JoinInner     JoinType = iota // [INNER] JOIN
-	JoinLeft                      // LEFT [OUTER] JOIN
-	JoinRight                     // RIGHT [OUTER] JOIN
-	JoinFullOuter                 // FULL OUTER JOIN
-	JoinCross                     // CROSS JOIN
+	JoinInner        JoinType = iota // [INNER] JOIN
+	JoinLeft                         // LEFT [OUTER] JOIN
+	JoinRight                        // RIGHT [OUTER] JOIN
+	JoinFullOuter                    // FULL OUTER JOIN
+	JoinCross                        // CROSS JOIN
+	JoinNatural                      // NATURAL JOIN
+	JoinNaturalLeft                  // NATURAL LEFT JOIN
+	JoinNaturalRight                 // NATURAL RIGHT JOIN
 )
 
 // JoinClause is one JOIN clause attached to a SELECT's FROM source.
@@ -423,6 +426,7 @@ type SelectFromSource struct {
 // prefix before the subquery (e.g. "t.id in" or "exists").
 type SelectStmt struct {
 	CTEs          []CTEDef // WITH clause; nil if no CTEs
+	Recursive     bool     // true when WITH RECURSIVE was used
 	Distinct      bool
 	Columns       []SelectItem
 	From          SelectFromSource

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -1066,7 +1066,7 @@ func (p *parser) parseCreateView() (Statement, error) {
 	var ctes []CTEDef
 	if p.curKeyword("WITH") {
 		var err error
-		ctes, err = p.parseCTEDefs()
+		ctes, _, err = p.parseCTEDefs()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -361,7 +361,8 @@ func (p *parser) isNextJoin() bool {
 		(p.curKeyword("LEFT") && (p.peekKeyword("JOIN") || p.peekKeyword("OUTER"))) ||
 		(p.curKeyword("RIGHT") && (p.peekKeyword("JOIN") || p.peekKeyword("OUTER"))) ||
 		(p.curKeyword("FULL") && (p.peekKeyword("OUTER") || p.peekKeyword("JOIN"))) ||
-		(p.curKeyword("CROSS") && p.peekKeyword("JOIN"))
+		(p.curKeyword("CROSS") && p.peekKeyword("JOIN")) ||
+		p.curKeyword("NATURAL")
 }
 
 // parseJoinClauses consumes zero or more JOIN clauses following a FROM source.
@@ -409,6 +410,33 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 			p.advance() // consume CROSS
 			p.advance() // consume JOIN
 			joinType = JoinCross
+		case p.curKeyword("NATURAL"):
+			p.advance() // consume NATURAL
+			switch {
+			case p.curKeyword("LEFT"):
+				p.advance() // consume LEFT
+				if p.curKeyword("OUTER") {
+					p.advance() // consume optional OUTER
+				}
+				if err := p.expectKeyword("JOIN"); err != nil {
+					return nil, err
+				}
+				joinType = JoinNaturalLeft
+			case p.curKeyword("RIGHT"):
+				p.advance() // consume RIGHT
+				if p.curKeyword("OUTER") {
+					p.advance() // consume optional OUTER
+				}
+				if err := p.expectKeyword("JOIN"); err != nil {
+					return nil, err
+				}
+				joinType = JoinNaturalRight
+			default:
+				if err := p.expectKeyword("JOIN"); err != nil {
+					return nil, err
+				}
+				joinType = JoinNatural
+			}
 		}
 
 		joinName, err := p.parseQualifiedName()
@@ -463,26 +491,31 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 //
 // WITH is consumed on entry. The caller is responsible for parsing the main
 // SELECT body that follows.
-func (p *parser) parseCTEDefs() ([]CTEDef, error) {
+func (p *parser) parseCTEDefs() ([]CTEDef, bool, error) {
 	p.advance() // consume WITH
+	recursive := false
+	if p.curKeyword("RECURSIVE") {
+		p.advance() // consume RECURSIVE
+		recursive = true
+	}
 	var ctes []CTEDef
 	for {
 		nameTok, err := p.expectIdent()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if err := p.expectKeyword("AS"); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if _, err := p.expect(lexer.LParen); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		body, err := p.parseSelectCore()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if _, err := p.expect(lexer.RParen); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		ctes = append(ctes, CTEDef{Name: nameTok.Value, Select: body})
 
@@ -491,11 +524,11 @@ func (p *parser) parseCTEDefs() ([]CTEDef, error) {
 		}
 		p.advance() // consume ','
 	}
-	return ctes, nil
+	return ctes, recursive, nil
 }
 
 func (p *parser) parseWithSelect() (Statement, error) {
-	ctes, err := p.parseCTEDefs()
+	ctes, recursive, err := p.parseCTEDefs()
 	if err != nil {
 		return nil, err
 	}
@@ -511,6 +544,7 @@ func (p *parser) parseWithSelect() (Statement, error) {
 		return nil, err
 	}
 	stmt.CTEs = ctes
+	stmt.Recursive = recursive
 
 	p.consumeSemicolon()
 	return stmt, nil


### PR DESCRIPTION
## Summary

- **#51 RECURSIVE CTEs**: `parseCTEDefs` returns a `bool` alongside the CTE list; `parseWithSelect` sets `SelectStmt.Recursive`; formatter emits `with recursive` when the flag is set. The `CREATE VIEW WITH CTE` path in `parse_ddl.go` discards the flag with `_`.
- **#53 NATURAL JOIN**: Three new `JoinType` constants (`JoinNatural`, `JoinNaturalLeft`, `JoinNaturalRight`); `isNextJoin` detects `NATURAL`; `parseJoinClauses` dispatches on `LEFT`/`RIGHT`/bare JOIN consuming optional `OUTER`. No ON/USING emitted. `NATURAL LEFT OUTER JOIN` normalises to `natural left join`.

Closes #51, #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)