### PR TITLE
feat: parse and format GROUP BY ROLLUP, CUBE, and GROUPING SETS

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -187,11 +187,23 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 	// GROUP BY
 	if len(s.GroupBy) > 0 {
 		b.WriteString("\n" + f.kw("group by"))
-		groupByStrs := make([]string, len(s.GroupBy))
-		for i, g := range s.GroupBy {
-			groupByStrs[i] = parser.Render(g)
+		// Single modifier with no other items: keyword on the "group by" line,
+		// arguments indented on the next line (e.g. "group by rollup\n\t(a, b)").
+		if len(s.GroupBy) == 1 && s.GroupBy[0].Modifier != parser.GroupBySimple && s.GroupBy[0].Modifier != parser.GroupByGrandTotal {
+			item := s.GroupBy[0]
+			b.WriteString(" " + f.kw(groupByModKeyword(item.Modifier)))
+			b.WriteString("\n" + ind + item.RawArgs)
+		} else {
+			groupByStrs := make([]string, len(s.GroupBy))
+			for i, item := range s.GroupBy {
+				if item.Modifier == parser.GroupBySimple {
+					groupByStrs[i] = parser.Render(item.Expr)
+				} else {
+					groupByStrs[i] = f.kw(groupByModKeyword(item.Modifier)) + item.RawArgs
+				}
+			}
+			f.writeCommaList(&b, groupByStrs)
 		}
-		f.writeCommaList(&b, groupByStrs)
 	}
 
 	// HAVING
@@ -270,6 +282,20 @@ func setOpKeyword(op parser.SetOpType) string {
 		return "except"
 	}
 	return "union"
+}
+
+// groupByModKeyword returns the canonical lowercase keyword phrase for a
+// GroupByModifier. GroupBySimple and GroupByGrandTotal have no keyword prefix.
+func groupByModKeyword(mod parser.GroupByModifier) string {
+	switch mod {
+	case parser.GroupByRollup:
+		return "rollup"
+	case parser.GroupByCube:
+		return "cube"
+	case parser.GroupBySets:
+		return "grouping sets"
+	}
+	return ""
 }
 
 // joinKeyword returns the canonical lowercase keyword phrase for a JoinType.

--- a/internal/formatter/testdata/group-by-extensions.input.sql
+++ b/internal/formatter/testdata/group-by-extensions.input.sql
@@ -1,0 +1,6 @@
+SELECT region, territory, SUM(sales) AS total FROM sales_data AS s GROUP BY ROLLUP(region, territory);
+SELECT region, SUM(sales) AS total FROM sales_data AS s GROUP BY CUBE(region);
+SELECT region, SUM(sales) AS total FROM sales_data AS s GROUP BY GROUPING SETS((region, territory), (region), ());
+SELECT SUM(sales) AS total FROM sales_data AS s GROUP BY ();
+SELECT region, territory, SUM(sales) AS total FROM sales_data AS s GROUP BY region, ROLLUP(territory);
+SELECT region, SUM(sales) AS total FROM sales_data AS s GROUP BY ROLLUP(region), CUBE(territory);

--- a/internal/formatter/testdata/group-by-extensions.sql
+++ b/internal/formatter/testdata/group-by-extensions.sql
@@ -1,0 +1,50 @@
+select
+	region
+,	territory
+,	sum(sales) as total
+from
+	sales_data as s
+group by rollup
+	(region, territory);
+
+select
+	region
+,	sum(sales) as total
+from
+	sales_data as s
+group by cube
+	(region);
+
+select
+	region
+,	sum(sales) as total
+from
+	sales_data as s
+group by grouping sets
+	((region, territory), (region), ());
+
+select
+	sum(sales) as total
+from
+	sales_data as s
+group by
+	();
+
+select
+	region
+,	territory
+,	sum(sales) as total
+from
+	sales_data as s
+group by
+	region
+,	rollup(territory);
+
+select
+	region
+,	sum(sales) as total
+from
+	sales_data as s
+group by
+	rollup(region)
+,	cube(territory);

--- a/internal/lexer/keywords.go
+++ b/internal/lexer/keywords.go
@@ -101,6 +101,11 @@ var keywords = map[string]bool{
 	"CHECK":      true,
 	"DEFAULT":    true,
 	"CONSTRAINT": true,
+	// GROUP BY extensions
+	"ROLLUP":   true,
+	"CUBE":     true,
+	"GROUPING": true,
+	"SETS":     true,
 	// Functions / misc
 	"TOP":       true,
 	"TIES":      true,

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -419,6 +419,28 @@ type WindowDef struct {
 	Spec string // raw window spec content (between the parens)
 }
 
+// GroupByModifier identifies the form of a GROUP BY item.
+type GroupByModifier int
+
+const (
+	GroupBySimple     GroupByModifier = iota // plain expression
+	GroupByRollup                            // ROLLUP(...)
+	GroupByCube                              // CUBE(...)
+	GroupBySets                              // GROUPING SETS(...)
+	GroupByGrandTotal                        // () grand total
+)
+
+// GroupByItem is one element in a GROUP BY clause.
+// For GroupBySimple, Expr holds the expression.
+// For GroupByRollup, GroupByCube, and GroupBySets, RawArgs holds the
+// parenthesised argument list as a raw string (e.g. "(a, b)").
+// For GroupByGrandTotal, RawArgs is "()".
+type GroupByItem struct {
+	Modifier GroupByModifier
+	Expr     Expr   // GroupBySimple only
+	RawArgs  string // Rollup / Cube / Sets / GrandTotal
+}
+
 // SelectFromSource is the target of a FROM clause.
 // Exactly one of Name (a table name) or Subquery is non-zero.
 type SelectFromSource struct {
@@ -443,19 +465,19 @@ type SelectStmt struct {
 	TopWithTies   bool   // true when WITH TIES modifier present
 	Columns       []SelectItem
 	From          SelectFromSource
-	Joins         []JoinClause // nil if no JOINs
-	Where         Expr         // WHERE predicate; nil if WhereSubq is set
-	WherePred     string       // expression before a WHERE subquery (e.g. "t.id in", "exists")
-	WhereSubq     *SelectStmt  // structured WHERE subquery; nil if Where is set
-	GroupBy       []Expr       // GROUP BY expressions; nil if absent
-	Having        Expr         // HAVING predicate; nil if absent
-	Windows       []WindowDef  // WINDOW clause definitions; nil if absent
-	SetOps        []SetOp      // UNION/INTERSECT/EXCEPT branches; nil for a plain SELECT
-	OrderBy       []OrderItem  // ORDER BY items; nil if absent; applies to whole compound query when SetOps non-nil
-	Offset        string       // n from OFFSET n ROWS; empty if absent
-	OffsetHasRows bool         // true when ROWS or ROW keyword followed the offset value
-	Fetch         string       // n from FETCH NEXT n ROWS ONLY; empty if absent
-	Limit         string       // n from LIMIT n (non-ANSI); empty if absent
+	Joins         []JoinClause  // nil if no JOINs
+	Where         Expr          // WHERE predicate; nil if WhereSubq is set
+	WherePred     string        // expression before a WHERE subquery (e.g. "t.id in", "exists")
+	WhereSubq     *SelectStmt   // structured WHERE subquery; nil if Where is set
+	GroupBy       []GroupByItem // GROUP BY items; nil if absent
+	Having        Expr          // HAVING predicate; nil if absent
+	Windows       []WindowDef   // WINDOW clause definitions; nil if absent
+	SetOps        []SetOp       // UNION/INTERSECT/EXCEPT branches; nil for a plain SELECT
+	OrderBy       []OrderItem   // ORDER BY items; nil if absent; applies to whole compound query when SetOps non-nil
+	Offset        string        // n from OFFSET n ROWS; empty if absent
+	OffsetHasRows bool          // true when ROWS or ROW keyword followed the offset value
+	Fetch         string        // n from FETCH NEXT n ROWS ONLY; empty if absent
+	Limit         string        // n from LIMIT n (non-ANSI); empty if absent
 }
 
 func (*SelectStmt) statementNode() {}

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -352,25 +352,83 @@ func (p *parser) parseFromSource() (SelectFromSource, error) {
 	return source, nil
 }
 
-// parseGroupByList parses a comma-separated list of GROUP BY expressions.
-func (p *parser) parseGroupByList() ([]Expr, error) {
-	var exprs []Expr
+// parseGroupByList parses a comma-separated list of GROUP BY items,
+// each of which may be a plain expression, ROLLUP(...), CUBE(...),
+// GROUPING SETS(...), or a grand-total ().
+func (p *parser) parseGroupByList() ([]GroupByItem, error) {
+	var items []GroupByItem
 	for {
-		expr := p.parseExpr(func() bool {
-			return p.curIs(lexer.Comma) || p.curKeyword("HAVING") ||
-				p.curKeyword("WINDOW") ||
-				p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
-				p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
-				p.isSetOpKeyword() ||
-				p.curIs(lexer.Semicolon)
-		})
-		exprs = append(exprs, expr)
+		item, err := p.parseGroupByItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
 		if !p.curIs(lexer.Comma) {
 			break
 		}
 		p.advance() // consume ','
 	}
-	return exprs, nil
+	return items, nil
+}
+
+// parseGroupByItem parses one element of a GROUP BY list.
+func (p *parser) parseGroupByItem() (GroupByItem, error) {
+	// ROLLUP(...)
+	if p.curKeyword("ROLLUP") {
+		p.advance() // consume ROLLUP
+		raw, err := p.parseParenRaw()
+		if err != nil {
+			return GroupByItem{}, err
+		}
+		return GroupByItem{Modifier: GroupByRollup, RawArgs: raw}, nil
+	}
+	// CUBE(...)
+	if p.curKeyword("CUBE") {
+		p.advance() // consume CUBE
+		raw, err := p.parseParenRaw()
+		if err != nil {
+			return GroupByItem{}, err
+		}
+		return GroupByItem{Modifier: GroupByCube, RawArgs: raw}, nil
+	}
+	// GROUPING SETS(...)
+	if p.curKeyword("GROUPING") && p.peekKeyword("SETS") {
+		p.advance() // consume GROUPING
+		p.advance() // consume SETS
+		raw, err := p.parseParenRaw()
+		if err != nil {
+			return GroupByItem{}, err
+		}
+		return GroupByItem{Modifier: GroupBySets, RawArgs: raw}, nil
+	}
+	// () — grand total grouping set
+	if p.curIs(lexer.LParen) && p.peek.Type == lexer.RParen {
+		p.advance() // consume (
+		p.advance() // consume )
+		return GroupByItem{Modifier: GroupByGrandTotal, RawArgs: "()"}, nil
+	}
+	// Plain expression
+	stopFn := func() bool {
+		return p.curIs(lexer.Comma) || p.curKeyword("HAVING") ||
+			p.curKeyword("WINDOW") ||
+			p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
+			p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+			p.isSetOpKeyword() ||
+			p.curIs(lexer.Semicolon)
+	}
+	expr := p.parseExpr(stopFn)
+	return GroupByItem{Modifier: GroupBySimple, Expr: expr}, nil
+}
+
+// parseParenRaw consumes '(' <raw-content> ')' and returns the whole
+// thing including the surrounding parens as a normalised raw string.
+func (p *parser) parseParenRaw() (string, error) {
+	if _, err := p.expect(lexer.LParen); err != nil {
+		return "", err
+	}
+	raw, _ := p.parseExprRaw(func() bool { return false })
+	p.advance() // consume closing )
+	return "(" + raw + ")", nil
 }
 
 // parseOrderByList parses a comma-separated list of ORDER BY items.

--- a/internal/parser/parse_select_test.go
+++ b/internal/parser/parse_select_test.go
@@ -98,7 +98,7 @@ func TestParseSelectGroupByHaving(t *testing.T) {
 	if Render(stmt.Columns[2].Value) != "sum(t.total_amount)" {
 		t.Errorf("Columns[2].Value: got %q, want %q", Render(stmt.Columns[2].Value), "sum(t.total_amount)")
 	}
-	if len(stmt.GroupBy) != 1 || Render(stmt.GroupBy[0]) != "t.status" {
+	if len(stmt.GroupBy) != 1 || Render(stmt.GroupBy[0].Expr) != "t.status" {
 		t.Errorf("GroupBy: got %v", stmt.GroupBy)
 	}
 	if Render(stmt.Having) != "count(*) > 10" {
@@ -286,7 +286,7 @@ func TestParseSelectFromSubquery(t *testing.T) {
 	if subq.From.Name != "orders" || subq.From.Alias != "t" {
 		t.Errorf("Subquery.From: got {Name:%q Alias:%q}", subq.From.Name, subq.From.Alias)
 	}
-	if len(subq.GroupBy) != 1 || Render(subq.GroupBy[0]) != "t.status" {
+	if len(subq.GroupBy) != 1 || Render(subq.GroupBy[0].Expr) != "t.status" {
 		t.Errorf("Subquery.GroupBy: got %v", subq.GroupBy)
 	}
 	if Render(stmt.Where) != "s.order_count > 5" {
@@ -302,11 +302,11 @@ func TestParseSelectGroupByMultiple(t *testing.T) {
 	if len(stmt.GroupBy) != 2 {
 		t.Fatalf("GroupBy: got %d items, want 2", len(stmt.GroupBy))
 	}
-	if Render(stmt.GroupBy[0]) != "c.id" {
-		t.Errorf("GroupBy[0]: got %q, want %q", Render(stmt.GroupBy[0]), "c.id")
+	if Render(stmt.GroupBy[0].Expr) != "c.id" {
+		t.Errorf("GroupBy[0]: got %q, want %q", Render(stmt.GroupBy[0].Expr), "c.id")
 	}
-	if Render(stmt.GroupBy[1]) != "c.name" {
-		t.Errorf("GroupBy[1]: got %q, want %q", Render(stmt.GroupBy[1]), "c.name")
+	if Render(stmt.GroupBy[1].Expr) != "c.name" {
+		t.Errorf("GroupBy[1]: got %q, want %q", Render(stmt.GroupBy[1].Expr), "c.name")
 	}
 }
 
@@ -472,7 +472,7 @@ func TestParseCTESingle(t *testing.T) {
 	if len(stmt.Joins) != 1 || stmt.Joins[0].Name != "customers" {
 		t.Errorf("main Joins: got %v", stmt.Joins)
 	}
-	if len(stmt.GroupBy) != 1 || Render(stmt.GroupBy[0]) != "c.name" {
+	if len(stmt.GroupBy) != 1 || Render(stmt.GroupBy[0].Expr) != "c.name" {
 		t.Errorf("main GroupBy: got %v", stmt.GroupBy)
 	}
 	if len(stmt.OrderBy) != 1 || Render(stmt.OrderBy[0].Value) != "lifetime_value" || stmt.OrderBy[0].Direction != DirectionDesc {
@@ -496,7 +496,7 @@ func TestParseCTEMultiple(t *testing.T) {
 	if stmt.CTEs[1].Select == nil {
 		t.Fatal("CTEs[1].Select: got nil, want non-nil")
 	}
-	if len(stmt.CTEs[1].Select.GroupBy) != 1 || Render(stmt.CTEs[1].Select.GroupBy[0]) != "t.customer_id" {
+	if len(stmt.CTEs[1].Select.GroupBy) != 1 || Render(stmt.CTEs[1].Select.GroupBy[0].Expr) != "t.customer_id" {
 		t.Errorf("CTEs[1].GroupBy: got %v", stmt.CTEs[1].Select.GroupBy)
 	}
 	// main SELECT


### PR DESCRIPTION
## Summary

- `SelectStmt.GroupBy` changes from `[]Expr` to `[]GroupByItem` with a `GroupByModifier` discriminator
- Plain expressions (`GroupBySimple`) wrap the existing `Expr` field — no behaviour change for existing queries
- `GroupByRollup`, `GroupByCube`, `GroupBySets` store their parenthesised argument lists as normalised raw strings via the new `parseParenRaw` helper
- `GroupByGrandTotal` represents the standalone `()` form
- Single-modifier GROUP BY emits `group by rollup\n\t(args)` per the issue spec; mixed lists render modifiers inline via `writeCommaList`

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)