### PR TITLE
feat: lint must-be-only-statement-in-batch

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ const (
 	RuleOneObjectPerFile            = "one-object-per-file"
 	RuleIdentifierWithSpaces        = "identifier-with-spaces"
 	RuleMissingBeginEnd             = "missing-begin-end"
+	RuleMustBeOnlyStatement         = "must-be-only-statement-in-batch"
 )
 
 // knownRules is the set of valid lint rule names for config validation.
@@ -91,6 +92,7 @@ var knownRules = map[string]bool{
 	RuleOneObjectPerFile:            true,
 	RuleIdentifierWithSpaces:        true,
 	RuleMissingBeginEnd:             true,
+	RuleMustBeOnlyStatement:         true,
 }
 
 // Config holds all formatting and linting options for sqlfmt.

--- a/internal/linter/lint_batch_test.go
+++ b/internal/linter/lint_batch_test.go
@@ -1,0 +1,126 @@
+package linter
+
+import (
+	"testing"
+
+	"github.com/rpf3/sqlfmt/internal/config"
+)
+
+func lintBatch(t *testing.T, input string) []Warning {
+	t.Helper()
+	cfg := config.Default()
+	// Suppress other rules so only must-be-only-statement-in-batch is relevant.
+	cfg.LintRules = map[string]config.RuleSeverity{
+		config.RuleMissingSchemaName:        config.RuleSeverityOff,
+		config.RuleUnaliasedTable:           config.RuleSeverityOff,
+		config.RuleMissingTrailingSemicolon: config.RuleSeverityOff,
+		config.RuleOneObjectPerFile:         config.RuleSeverityOff,
+		config.RuleMissingBeginEnd:          config.RuleSeverityOff,
+	}
+	warnings, err := Lint(input, cfg)
+	if err != nil {
+		t.Fatalf("Lint returned unexpected error: %v", err)
+	}
+	return warnings
+}
+
+func TestLintMustBeOnlyStatement(t *testing.T) {
+	rule := config.RuleMustBeOnlyStatement
+
+	t.Run("single CREATE VIEW is clean", func(t *testing.T) {
+		warnings := lintBatch(t, `create view v as select id from orders as o;`)
+		if hasRule(warnings, rule) {
+			t.Errorf("expected no %q warning, got %v", rule, warnings)
+		}
+	})
+
+	t.Run("single CREATE PROCEDURE is clean", func(t *testing.T) {
+		warnings := lintBatch(t, `create procedure dbo.up_foo as begin select 1; end;`)
+		if hasRule(warnings, rule) {
+			t.Errorf("expected no %q warning, got %v", rule, warnings)
+		}
+	})
+
+	t.Run("single CREATE FUNCTION is clean", func(t *testing.T) {
+		warnings := lintBatch(t, `create function dbo.fn_foo() returns int as begin return 1; end;`)
+		if hasRule(warnings, rule) {
+			t.Errorf("expected no %q warning, got %v", rule, warnings)
+		}
+	})
+
+	t.Run("CREATE VIEW plus SELECT warns", func(t *testing.T) {
+		warnings := lintBatch(t,
+			`create view order_summary as select id from orders as o;
+			 select id from orders as o;`)
+		if !hasRule(warnings, rule) {
+			t.Errorf("expected %q warning, got none", rule)
+		}
+	})
+
+	t.Run("CREATE PROCEDURE plus SELECT warns", func(t *testing.T) {
+		warnings := lintBatch(t,
+			`create procedure dbo.up_foo as begin select id from orders as o; end;
+			 select id from orders as o;`)
+		if !hasRule(warnings, rule) {
+			t.Errorf("expected %q warning, got none", rule)
+		}
+	})
+
+	t.Run("CREATE FUNCTION plus SELECT warns", func(t *testing.T) {
+		warnings := lintBatch(t,
+			`create function dbo.fn_foo() returns int as begin return 1; end;
+			 select id from orders as o;`)
+		if !hasRule(warnings, rule) {
+			t.Errorf("expected %q warning, got none", rule)
+		}
+	})
+
+	t.Run("CREATE TYPE AS TABLE plus SELECT warns", func(t *testing.T) {
+		warnings := lintBatch(t,
+			`create type dbo.OrderIds as table (id int not null);
+			 select id from orders as o;`)
+		if !hasRule(warnings, rule) {
+			t.Errorf("expected %q warning, got none", rule)
+		}
+	})
+
+	t.Run("CREATE TYPE AS ENUM is exempt", func(t *testing.T) {
+		warnings := lintBatch(t,
+			`create type status_t from varchar(20);
+			 select id from orders as o;`)
+		if hasRule(warnings, rule) {
+			t.Errorf("expected no %q warning for non-table type, got %v", rule, warnings)
+		}
+	})
+
+	t.Run("two SELECT statements is clean", func(t *testing.T) {
+		warnings := lintBatch(t,
+			`select id from orders as o;
+			 select id from customers as c;`)
+		if hasRule(warnings, rule) {
+			t.Errorf("expected no %q warning for plain SELECTs, got %v", rule, warnings)
+		}
+	})
+
+	t.Run("rule off suppresses warning", func(t *testing.T) {
+		cfg := config.Default()
+		cfg.LintRules = map[string]config.RuleSeverity{
+			rule:                                config.RuleSeverityOff,
+			config.RuleMissingSchemaName:        config.RuleSeverityOff,
+			config.RuleUnaliasedTable:           config.RuleSeverityOff,
+			config.RuleMissingTrailingSemicolon: config.RuleSeverityOff,
+			config.RuleOneObjectPerFile:         config.RuleSeverityOff,
+			config.RuleMissingBeginEnd:          config.RuleSeverityOff,
+		}
+		warnings, err := Lint(
+			`create view order_summary as select id from orders as o;
+			 select id from orders as o;`,
+			cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if hasRule(warnings, rule) {
+			t.Errorf("expected rule suppressed, got %v", warnings)
+		}
+	})
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -32,6 +32,7 @@ func Lint(input string, cfg config.Config) ([]Warning, error) {
 		}
 	}
 	l.checkOneObjectPerFile(result.Statements)
+	l.checkMustBeOnlyStatement(result.Statements)
 	return l.warnings, nil
 }
 
@@ -82,6 +83,37 @@ func (l *linter) checkOneObjectPerFile(stmts []parser.Statement) {
 	l.warn(config.RuleOneObjectPerFile,
 		fmt.Sprintf("file defines multiple objects (%s); each object should have its own file",
 			strings.Join(names, ", ")))
+}
+
+// checkMustBeOnlyStatement warns when CREATE VIEW, CREATE PROCEDURE,
+// CREATE FUNCTION, or CREATE TYPE AS TABLE appears alongside other statements
+// in the same batch. These DDL statements require an exclusive batch in T-SQL.
+func (l *linter) checkMustBeOnlyStatement(stmts []parser.Statement) {
+	sev := l.severity(config.RuleMustBeOnlyStatement)
+	if sev == config.RuleSeverityOff {
+		return
+	}
+	if len(stmts) <= 1 {
+		return
+	}
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *parser.CreateViewStmt:
+			l.warn(config.RuleMustBeOnlyStatement,
+				fmt.Sprintf("CREATE VIEW %q must be the only statement in the batch", s.Name))
+		case *parser.CreateProcStmt:
+			l.warn(config.RuleMustBeOnlyStatement,
+				fmt.Sprintf("CREATE PROCEDURE %q must be the only statement in the batch", s.Name))
+		case *parser.CreateFuncStmt:
+			l.warn(config.RuleMustBeOnlyStatement,
+				fmt.Sprintf("CREATE FUNCTION %q must be the only statement in the batch", s.Name))
+		case *parser.CreateTypeStmt:
+			if s.Kind == parser.CreateTypeTable {
+				l.warn(config.RuleMustBeOnlyStatement,
+					fmt.Sprintf("CREATE TYPE %q must be the only statement in the batch", s.Name))
+			}
+		}
+	}
 }
 
 // linter holds configuration and accumulates warnings during a lint run.


### PR DESCRIPTION
## Summary

- Adds `must-be-only-statement-in-batch` lint rule to `config.go` (constant + `knownRules` entry)
- Implements `checkMustBeOnlyStatement()` in `linter.go`, wired into `Lint()` after the existing batch-level checks
- Warns once per offending DDL statement when CREATE VIEW, CREATE PROCEDURE, CREATE FUNCTION, or CREATE TYPE AS TABLE appears alongside other statements in the same batch
- CREATE TYPE scalar/alias kinds are exempt (no batch restriction)
- New `lint_batch_test.go` covers single-statement clean, each DDL type triggering the rule, non-table TYPE exemption, plain SELECT pairs, and rule-off suppression

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)