### PR TITLE
feat: parse and format DECLARE statement

### DIFF
--- a/internal/formatter/format_ddl.go
+++ b/internal/formatter/format_ddl.go
@@ -703,3 +703,66 @@ func (f *formatter) formatSet(s *parser.SetStmt) string {
 	}
 	return b.String()
 }
+
+func (f *formatter) formatDeclare(s *parser.DeclareStmt) string {
+	ind := f.indent()
+	var b strings.Builder
+
+	// Table variable — single var with a column list.
+	if len(s.Vars) == 1 && len(s.Vars[0].Columns) > 0 {
+		v := s.Vars[0]
+		b.WriteString(f.kw("declare "))
+		b.WriteString(v.Name)
+		b.WriteString(" " + f.kw("table"))
+		b.WriteString("\n(\n")
+		cols := v.Columns
+		for i, col := range cols {
+			if f.cfg.CommaStyle == config.CommaTrailing {
+				b.WriteString(ind)
+				f.writeColumnDef(&b, col)
+				if i < len(cols)-1 {
+					b.WriteString(",")
+				}
+			} else {
+				if i == 0 {
+					b.WriteString(ind)
+				} else {
+					b.WriteString("," + ind)
+				}
+				f.writeColumnDef(&b, col)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString(");")
+		return b.String()
+	}
+
+	// Single scalar variable — keep on one line.
+	if len(s.Vars) == 1 {
+		v := s.Vars[0]
+		b.WriteString(f.kw("declare "))
+		b.WriteString(v.Name)
+		b.WriteString(" ")
+		b.WriteString(strings.ToLower(v.Type))
+		if v.Default != nil {
+			b.WriteString(" = ")
+			b.WriteString(parser.Render(v.Default))
+		}
+		b.WriteString(";")
+		return b.String()
+	}
+
+	// Multiple scalar variables — one per line via comma list.
+	b.WriteString(f.kw("declare"))
+	items := make([]string, len(s.Vars))
+	for i, v := range s.Vars {
+		item := v.Name + " " + strings.ToLower(v.Type)
+		if v.Default != nil {
+			item += " = " + parser.Render(v.Default)
+		}
+		items[i] = item
+	}
+	f.writeCommaList(&b, items)
+	b.WriteString(";")
+	return b.String()
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -86,6 +86,8 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 		return f.formatUpdate(s)
 	case *parser.SetStmt:
 		return f.formatSet(s)
+	case *parser.DeclareStmt:
+		return f.formatDeclare(s)
 	case *parser.MergeStmt:
 		return f.formatMerge(s)
 	case *parser.SelectStmt:

--- a/internal/formatter/testdata/declare.input.sql
+++ b/internal/formatter/testdata/declare.input.sql
@@ -1,0 +1,6 @@
+DECLARE @count INT;
+DECLARE @name VARCHAR(50) = 'default';
+DECLARE @total INT = 0;
+DECLARE @count INT, @name VARCHAR(50);
+DECLARE @count INT, @name VARCHAR(50), @total INT;
+DECLARE @results TABLE (id INT NOT NULL, name VARCHAR(50) NOT NULL);

--- a/internal/formatter/testdata/declare.sql
+++ b/internal/formatter/testdata/declare.sql
@@ -1,0 +1,20 @@
+declare @count int;
+
+declare @name varchar(50) = 'default';
+
+declare @total int = 0;
+
+declare
+	@count int
+,	@name varchar(50);
+
+declare
+	@count int
+,	@name varchar(50)
+,	@total int;
+
+declare @results table
+(
+	id int not null
+,	name varchar(50) not null
+);

--- a/internal/lexer/keywords.go
+++ b/internal/lexer/keywords.go
@@ -77,6 +77,7 @@ var keywords = map[string]bool{
 	"WITH":      true,
 	"RECURSIVE": true,
 	// Transactions / flow control
+	"DECLARE":      true,
 	"BEGIN":        true,
 	"COMMIT":       true,
 	"ROLLBACK":     true,

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -278,6 +278,25 @@ type SetStmt struct {
 
 func (*SetStmt) statementNode() {}
 
+// VarDecl is one variable declaration in a DECLARE statement.
+// Exactly one of Type (scalar) or Columns (table variable) is populated.
+type VarDecl struct {
+	Name    string      // includes @ prefix, e.g. "@count"
+	Type    string      // data type for scalar variable; empty for table variable
+	Default Expr        // optional initialiser after =; nil if absent
+	Columns []ColumnDef // column list for table variable; nil for scalar
+}
+
+// DeclareStmt represents a T-SQL DECLARE statement.
+//
+//	DECLARE @name type [= default] [, @name2 type2 ...]  -- scalar variable(s)
+//	DECLARE @name TABLE (<col_defs>)                      -- table variable
+type DeclareStmt struct {
+	Vars []VarDecl
+}
+
+func (*DeclareStmt) statementNode() {}
+
 // UpdateSet is one col = expr assignment in an UPDATE SET clause.
 type UpdateSet struct {
 	Column string // column name, possibly qualified (e.g. "o.status")

--- a/internal/parser/parse_ddl.go
+++ b/internal/parser/parse_ddl.go
@@ -1562,6 +1562,66 @@ func (p *parser) parseMergeSetClause() ([]UpdateSet, error) {
 	return sets, nil
 }
 
+// parseDeclare handles:
+//
+//	DECLARE @name type [= default] [, @name2 type2 ...]  -- scalar variable(s)
+//	DECLARE @name TABLE (<col_defs>)                      -- table variable
+func (p *parser) parseDeclare() (Statement, error) {
+	p.advance() // consume DECLARE
+	var vars []VarDecl
+	for {
+		nameTok, err := p.expectIdent()
+		if err != nil {
+			return nil, err
+		}
+		name := nameTok.Value
+
+		if p.curKeyword("TABLE") {
+			p.advance() // consume TABLE
+			if _, err := p.expect(lexer.LParen); err != nil {
+				return nil, err
+			}
+			cols, _, err := p.parseColumnList()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(lexer.RParen); err != nil {
+				return nil, err
+			}
+			vars = append(vars, VarDecl{Name: name, Columns: cols})
+		} else {
+			dataType, err := p.parseDataType()
+			if err != nil {
+				return nil, err
+			}
+			v := VarDecl{Name: name, Type: dataType}
+			if p.curIs(lexer.Eq) {
+				p.advance() // consume =
+				tok := p.cur
+				switch tok.Type {
+				case lexer.StringLit, lexer.IntLit, lexer.FloatLit, lexer.Keyword, lexer.Ident:
+					v.Default = &RawExpr{Text: tok.Value}
+					p.advance()
+				default:
+					return nil, fmt.Errorf(
+						"expected default value after = at %d:%d, got %s %q",
+						tok.Line, tok.Column, tok.Type, tok.Value,
+					)
+				}
+			}
+			vars = append(vars, v)
+		}
+
+		if !p.curIs(lexer.Comma) {
+			break
+		}
+		p.advance() // consume ','
+	}
+	p.consumeSemicolon()
+	stmt := &DeclareStmt{Vars: vars}
+	return stmt, nil
+}
+
 // parseSet handles SET statement variants:
 //   - SET <option> <value>               (SetSimple)
 //   - SET TRANSACTION ISOLATION LEVEL …  (SetTransactionIsolation)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -211,6 +211,9 @@ func (p *parser) parseStatement() (Statement, error) {
 	if p.curKeyword("MERGE") {
 		return p.parseMerge()
 	}
+	if p.curKeyword("DECLARE") {
+		return p.parseDeclare()
+	}
 	return nil, fmt.Errorf(
 		"unexpected token %s %q at %d:%d",
 		p.cur.Type, p.cur.Value, p.cur.Line, p.cur.Column,


### PR DESCRIPTION
## Summary

- Adds `DECLARE` to the keyword list (`lexer/keywords.go`)
- New `DeclareStmt` / `VarDecl` AST nodes in `parser/ast.go`
- `parseDeclare()` in `parse_ddl.go` handles scalar variables (with optional `= default`), multi-variable comma lists, and `TABLE (...)` column blocks
- `formatDeclare()` in `format_ddl.go`:
  - Single scalar: inline — `declare @name type [= default];`
  - Multiple scalars: `declare` on own line, vars via `writeCommaList` (respects `comma_style`)
  - Table variable: `declare @name table\n(\n<cols>\n);` — identical column-block style to `CREATE TABLE`
- Golden test pair `testdata/declare.{input,}.sql` covering all three forms

Default expressions are stored as a single `RawExpr` token, consistent with column `DEFAULT` values. Subquery defaults are deferred to #97.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)