### PR TITLE
test: DDL parser unit tests

### DIFF
--- a/internal/parser/parse_ddl_test.go
+++ b/internal/parser/parse_ddl_test.go
@@ -1270,3 +1270,177 @@ func TestParseDeclare(t *testing.T) {
 		}
 	})
 }
+
+// ─── parseProcParams tests ────────────────────────────────────────────────────
+
+// parseProcParams stops at AS/BEGIN/)/EOF, so we can feed it just the param
+// fragment without needing a full CREATE PROC statement.
+func mustParseProcParams(t *testing.T, sql string) []ProcParam {
+	t.Helper()
+	p := newTestParser(sql)
+	params, err := p.parseProcParams()
+	if err != nil {
+		t.Fatalf("parseProcParams(%q): unexpected error: %v", sql, err)
+	}
+	return params
+}
+
+func TestParseProcParams(t *testing.T) {
+	// ── Empty / no params ─────────────────────────────────────────────────────
+
+	t.Run("no params terminated by AS", func(t *testing.T) {
+		params := mustParseProcParams(t, "as")
+		if len(params) != 0 {
+			t.Errorf("params: got %d, want 0", len(params))
+		}
+	})
+
+	t.Run("empty parenthesised list", func(t *testing.T) {
+		params := mustParseProcParams(t, "()")
+		if len(params) != 0 {
+			t.Errorf("params: got %d, want 0", len(params))
+		}
+	})
+
+	// ── Single param — basic ──────────────────────────────────────────────────
+
+	t.Run("single param no default", func(t *testing.T) {
+		params := mustParseProcParams(t, "@count int")
+		if len(params) != 1 {
+			t.Fatalf("params: got %d, want 1", len(params))
+		}
+		if params[0].Name != "@count" {
+			t.Errorf("Name: got %q, want %q", params[0].Name, "@count")
+		}
+		if params[0].DataType != "INT" {
+			t.Errorf("DataType: got %q, want %q", params[0].DataType, "INT")
+		}
+		if params[0].Direction != ParamDirectionIn {
+			t.Errorf("Direction: got %v, want ParamDirectionIn", params[0].Direction)
+		}
+		if params[0].Default != nil {
+			t.Errorf("Default: got %q, want nil", renderExpr(params[0].Default))
+		}
+	})
+
+	t.Run("single param with MAX type", func(t *testing.T) {
+		params := mustParseProcParams(t, "@body nvarchar(max)")
+		if len(params) != 1 {
+			t.Fatalf("params: got %d, want 1", len(params))
+		}
+		if params[0].DataType != "NVARCHAR(MAX)" {
+			t.Errorf("DataType: got %q, want %q", params[0].DataType, "NVARCHAR(MAX)")
+		}
+	})
+
+	// ── Single param — defaults ───────────────────────────────────────────────
+
+	t.Run("single param with int default", func(t *testing.T) {
+		params := mustParseProcParams(t, "@count int = 0")
+		if renderExpr(params[0].Default) != "0" {
+			t.Errorf("Default: got %q, want %q", renderExpr(params[0].Default), "0")
+		}
+	})
+
+	t.Run("single param with string default", func(t *testing.T) {
+		params := mustParseProcParams(t, "@status varchar(20) = 'active'")
+		if renderExpr(params[0].Default) != "'active'" {
+			t.Errorf("Default: got %q, want %q", renderExpr(params[0].Default), "'active'")
+		}
+	})
+
+	t.Run("single param with null default", func(t *testing.T) {
+		params := mustParseProcParams(t, "@val int = null")
+		if renderExpr(params[0].Default) != "null" {
+			t.Errorf("Default: got %q, want %q", renderExpr(params[0].Default), "null")
+		}
+	})
+
+	// ── Single param — direction / modifiers ──────────────────────────────────
+
+	t.Run("output keyword", func(t *testing.T) {
+		params := mustParseProcParams(t, "@result int output")
+		if params[0].Direction != ParamDirectionOut {
+			t.Errorf("Direction: got %v, want ParamDirectionOut", params[0].Direction)
+		}
+	})
+
+	t.Run("out alias", func(t *testing.T) {
+		params := mustParseProcParams(t, "@result int out")
+		if params[0].Direction != ParamDirectionOut {
+			t.Errorf("Direction: got %v, want ParamDirectionOut", params[0].Direction)
+		}
+	})
+
+	t.Run("readonly consumed without error", func(t *testing.T) {
+		// READONLY is a hint (input-only); it is consumed but does not set Direction.
+		params := mustParseProcParams(t, "@data nvarchar(max) readonly")
+		if len(params) != 1 {
+			t.Fatalf("params: got %d, want 1", len(params))
+		}
+		if params[0].Direction != ParamDirectionIn {
+			t.Errorf("Direction: got %v, want ParamDirectionIn", params[0].Direction)
+		}
+	})
+
+	// ── Parenthesised form ────────────────────────────────────────────────────
+
+	t.Run("single param in parens", func(t *testing.T) {
+		params := mustParseProcParams(t, "(@count int)")
+		if len(params) != 1 {
+			t.Fatalf("params: got %d, want 1", len(params))
+		}
+		if params[0].Name != "@count" {
+			t.Errorf("Name: got %q, want %q", params[0].Name, "@count")
+		}
+	})
+
+	// ── Multiple params ───────────────────────────────────────────────────────
+
+	t.Run("multiple params no parens", func(t *testing.T) {
+		params := mustParseProcParams(t, "@a int, @b varchar(10), @c bit")
+		if len(params) != 3 {
+			t.Fatalf("params: got %d, want 3", len(params))
+		}
+		wantNames := []string{"@a", "@b", "@c"}
+		wantTypes := []string{"INT", "VARCHAR(10)", "BIT"}
+		for i, n := range wantNames {
+			if params[i].Name != n {
+				t.Errorf("params[%d].Name: got %q, want %q", i, params[i].Name, n)
+			}
+			if params[i].DataType != wantTypes[i] {
+				t.Errorf("params[%d].DataType: got %q, want %q", i, params[i].DataType, wantTypes[i])
+			}
+		}
+	})
+
+	t.Run("multiple params with parens mixed attributes", func(t *testing.T) {
+		params := mustParseProcParams(t, "(@id int, @name nvarchar(max) = null, @result int output)")
+		if len(params) != 3 {
+			t.Fatalf("params: got %d, want 3", len(params))
+		}
+		// @id — plain input
+		if params[0].Direction != ParamDirectionIn || params[0].Default != nil {
+			t.Errorf("params[0]: got direction=%v default=%q, want input/nil",
+				params[0].Direction, renderExpr(params[0].Default))
+		}
+		// @name — has default
+		if renderExpr(params[1].Default) != "null" {
+			t.Errorf("params[1].Default: got %q, want %q", renderExpr(params[1].Default), "null")
+		}
+		// @result — output
+		if params[2].Direction != ParamDirectionOut {
+			t.Errorf("params[2].Direction: got %v, want ParamDirectionOut", params[2].Direction)
+		}
+	})
+
+	// ── Error cases ───────────────────────────────────────────────────────────
+
+	t.Run("non-ident parameter name", func(t *testing.T) {
+		p := newTestParser("123 int")
+		_, err := p.parseProcParams()
+		if err == nil {
+			t.Error("expected error for numeric parameter name, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds white-box unit tests for DDL parser functions in `internal/parser/parse_ddl_test.go` (package `parser`, not `parser_test`, for access to unexported helpers)
- Covers 8 functions across 7 commits: `parseDataType`, `parseColumnDef`, `parseTableConstraint`, `parseCreateTable`, `parseCreateIndex`, `parseAlterTableAction`, `parseDeclare`, `parseProcParams`
- Each test file uses table-driven subtests with `t.Run` and a shared `newTestParser` helper that primes `cur`/`peek` tokens correctly
- Documents known parser behaviours (e.g. PRIMARY KEY ordering limitation, `parseCheckExpr` space-around-commas) as inline comments so future refactoring has a clear contract to preserve

## Commits

| Commit | Coverage |
|--------|----------|
| `0350885` | `parseDataType` + `parseColumnDef` |
| `8269def` | `parseTableConstraint` |
| `299ed04` | `parseCreateTable` |
| `8b9e7e2` | `parseCreateIndex` |
| `4b92eb9` | `parseAlterTableAction` |
| `42e77b0` | `parseDeclare` |
| `2d6d08b` | `parseProcParams` |

## Test plan

- [x] `go test ./internal/parser/...` passes locally
- [x] All subtests named and independently runnable via `-run TestParseColumnDef/identity_with_args`
- [x] No changes to production code — test-only PR

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)