### PR TITLE
feat: TOP (n) in UPDATE and DELETE (#156)

### DIFF
--- a/internal/formatter/format_dml.go
+++ b/internal/formatter/format_dml.go
@@ -47,6 +47,9 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 	ind := f.indent()
 	var b strings.Builder
 	b.WriteString(f.kw("update"))
+	if s.Top != "" {
+		b.WriteString(" " + f.kw("top") + " (" + s.Top + ")")
+	}
 	b.WriteString("\n")
 	b.WriteString(ind)
 	b.WriteString(f.ident(s.Target))
@@ -97,9 +100,13 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 func (f *formatter) formatDelete(s *parser.DeleteStmt) string {
 	ind := f.indent()
 	var b strings.Builder
+	topClause := ""
+	if s.Top != "" {
+		topClause = " " + f.kw("top") + " (" + s.Top + ")"
+	}
 	if s.Alias != "" {
-		// Multi-line form: DELETE <alias> FROM <table> AS <alias>
-		b.WriteString(f.kw("delete"))
+		// Multi-line form: DELETE [TOP (n)] <alias> FROM <table> AS <alias>
+		b.WriteString(f.kw("delete") + topClause)
 		b.WriteString("\n")
 		b.WriteString(ind)
 		b.WriteString(f.ident(s.Alias))
@@ -112,13 +119,13 @@ func (f *formatter) formatDelete(s *parser.DeleteStmt) string {
 		b.WriteString(f.ident(s.Alias))
 	} else if s.Where != nil {
 		// No alias but WHERE present: table on its own line for readability
-		b.WriteString(f.kw("delete from"))
+		b.WriteString(f.kw("delete") + topClause + " " + f.kw("from"))
 		b.WriteString("\n")
 		b.WriteString(ind)
 		b.WriteString(f.ident(s.Table))
 	} else {
 		// No alias, no WHERE: compact single line
-		b.WriteString(f.kw("delete from "))
+		b.WriteString(f.kw("delete") + topClause + " " + f.kw("from "))
 		b.WriteString(f.ident(s.Table))
 	}
 	if s.Where != nil {

--- a/internal/formatter/testdata/top-dml.input.sql
+++ b/internal/formatter/testdata/top-dml.input.sql
@@ -1,0 +1,7 @@
+UPDATE TOP (1000) orders SET status = 'archived' WHERE created_at < '2020-01-01';
+
+UPDATE TOP(500) dbo.orders SET status='archived';
+
+DELETE TOP (500) FROM orders WHERE status = 'cancelled';
+
+DELETE TOP(100) FROM dbo.orders;

--- a/internal/formatter/testdata/top-dml.sql
+++ b/internal/formatter/testdata/top-dml.sql
@@ -1,0 +1,18 @@
+update top (1000)
+	orders
+set
+	status = 'archived'
+where
+	created_at < '2020-01-01';
+
+update top (500)
+	dbo.orders
+set
+	status = 'archived';
+
+delete top (500) from
+	orders
+where
+	status = 'cancelled';
+
+delete top (100) from dbo.orders;

--- a/internal/parser/ast_dml.go
+++ b/internal/parser/ast_dml.go
@@ -2,8 +2,9 @@ package parser
 
 // ─── DELETE ───────────────────────────────────────────────────────────────────
 
-// DeleteStmt represents: DELETE [<alias>] FROM <table> [AS <alias>] [WHERE <predicate>]
+// DeleteStmt represents: DELETE [TOP (n)] [<alias>] FROM <table> [AS <alias>] [WHERE <predicate>]
 type DeleteStmt struct {
+	Top           string // expression inside TOP(n); empty if absent
 	Table         string // table name
 	Alias         string // table alias; empty if none
 	AliasExplicit bool   // true when the AS keyword preceded the alias
@@ -45,13 +46,14 @@ type UpdateFromSource struct {
 
 // UpdateStmt represents an UPDATE statement.
 //
-// ANSI:       UPDATE <table> SET <col=expr> [WHERE <pred>]
-// SQL Server: UPDATE <alias> SET <col=expr> FROM <table> AS <alias> [JOINs] [WHERE <pred>]
+// ANSI:       UPDATE [TOP (n)] <table> SET <col=expr> [WHERE <pred>]
+// SQL Server: UPDATE [TOP (n)] <alias> SET <col=expr> FROM <table> AS <alias> [JOINs] [WHERE <pred>]
 //
 // When From is nil the statement is ANSI style and Target is the table name.
 // When From is non-nil the statement is SQL Server style: Target is the alias
 // that appears after UPDATE, and From holds the FROM clause details.
 type UpdateStmt struct {
+	Top    string            // expression inside TOP(n); empty if absent
 	Target string            // table name (ANSI) or alias (SQL Server)
 	Sets   []UpdateSet       // SET assignments; always non-empty
 	From   *UpdateFromSource // non-nil for SQL Server FROM style

--- a/internal/parser/parse_dml.go
+++ b/internal/parser/parse_dml.go
@@ -6,6 +6,27 @@ import (
 	"github.com/rpf3/sqlfmt/internal/lexer"
 )
 
+// parseTopClause parses an optional TOP (n) clause immediately after a DML
+// keyword (UPDATE, DELETE). Returns the expression string inside the parens,
+// or empty string if TOP is not present. PERCENT and WITH TIES are not valid
+// in DML context and are not parsed here.
+func (p *parser) parseTopClause() string {
+	if !p.curKeyword("TOP") {
+		return ""
+	}
+	p.advance() // consume TOP
+	if p.curIs(lexer.LParen) {
+		p.advance() // consume (
+		expr, _ := p.parseExprRaw(func() bool { return false })
+		p.advance() // consume )
+		return expr
+	}
+	// bare TOP n (no parens)
+	val := p.cur.Value
+	p.advance()
+	return val
+}
+
 // parseInsert handles:
 //
 //	INSERT INTO <table> [(cols)] VALUES (...) [, (...)] [;]
@@ -89,11 +110,14 @@ func (p *parser) parseValueRow() ([]Expr, error) {
 func (p *parser) parseUpdate() (Statement, error) {
 	p.advance() // consume UPDATE
 
+	stmt := &UpdateStmt{}
+	stmt.Top = p.parseTopClause()
+
 	target, err := p.parseQualifiedName()
 	if err != nil {
 		return nil, err
 	}
-	stmt := &UpdateStmt{Target: target}
+	stmt.Target = target
 
 	sets, err := p.parseSetClause()
 	if err != nil {
@@ -209,6 +233,9 @@ func (p *parser) parseSetClause() ([]UpdateSet, error) {
 func (p *parser) parseDelete() (Statement, error) {
 	p.advance() // consume DELETE
 
+	stmt := &DeleteStmt{}
+	stmt.Top = p.parseTopClause()
+
 	// Optional pre-FROM alias (SQL Server style: DELETE alias FROM ...).
 	// We detect it by checking whether the current token is an identifier
 	// immediately followed by the FROM keyword.
@@ -225,7 +252,7 @@ func (p *parser) parseDelete() (Statement, error) {
 		return nil, err
 	}
 
-	stmt := &DeleteStmt{Table: deleteName}
+	stmt.Table = deleteName
 
 	if p.curKeyword("AS") {
 		p.advance()


### PR DESCRIPTION
## Summary

- Adds `Top string` field to `UpdateStmt` and `DeleteStmt`
- Extracts `parseTopClause()` helper shared by both parsers (mirrors the existing SELECT TOP block)
- Formatter emits `top (n)` inline on the same line as the DML keyword, table name on the next indented line — matching the established `select top (n)` style
- `PERCENT` and `WITH TIES` intentionally omitted: not valid in DML context

Closes #156

## Test plan

- [ ] `go test ./...` passes
- [ ] `TestFormatGolden` covers `top-dml.sql`
- [ ] `TestFormatIdempotent` confirms golden file is stable
- [ ] `task fmt && task vet && task lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)