### PR TITLE
feat: WITH CTEs in INSERT, UPDATE, and DELETE (#152)

### DIFF
--- a/internal/formatter/format_dml.go
+++ b/internal/formatter/format_dml.go
@@ -36,6 +36,7 @@ func (f *formatter) writeOutputClause(b *strings.Builder, out *parser.OutputClau
 
 func (f *formatter) formatInsert(s *parser.InsertStmt) string {
 	var b strings.Builder
+	f.writeCTEList(&b, s.CTEs, false)
 	b.WriteString(f.kw("insert into "))
 	b.WriteString(f.ident(s.Table))
 
@@ -76,6 +77,7 @@ func (f *formatter) formatInsert(s *parser.InsertStmt) string {
 func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 	ind := f.indent()
 	var b strings.Builder
+	f.writeCTEList(&b, s.CTEs, false)
 	b.WriteString(f.kw("update"))
 	if s.Top != "" {
 		b.WriteString(" " + f.kw("top") + " (" + s.Top + ")")
@@ -132,6 +134,7 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 func (f *formatter) formatDelete(s *parser.DeleteStmt) string {
 	ind := f.indent()
 	var b strings.Builder
+	f.writeCTEList(&b, s.CTEs, false)
 	topClause := ""
 	if s.Top != "" {
 		topClause = " " + f.kw("top") + " (" + s.Top + ")"

--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -66,33 +66,37 @@ func (f *formatter) indentSubquery(s *parser.SelectStmt) string {
 	return b.String()
 }
 
-func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
-	ind := f.indent()
-	var b strings.Builder
-
-	// WITH clause (CTEs)
-	for i, cte := range s.CTEs {
+// writeCTEList renders a WITH clause (one or more CTEs) into b.
+// recursive is only meaningful for SELECT; DML callers pass false.
+func (f *formatter) writeCTEList(b *strings.Builder, ctes []parser.CTEDef, recursive bool) {
+	for i, cte := range ctes {
 		if i == 0 {
 			withKw := f.kw("with")
-			if s.Recursive {
+			if recursive {
 				withKw = f.kw("with recursive")
 			}
 			b.WriteString(withKw + " " + f.ident(cte.Name) + " " + f.kw("as"))
 		} else if f.cfg.CommaStyle == config.CommaTrailing {
 			b.WriteString(f.ident(cte.Name) + " " + f.kw("as"))
 		} else {
-			// leading comma: ", name as"
 			b.WriteString(", " + f.ident(cte.Name) + " " + f.kw("as"))
 		}
 		b.WriteString("\n(\n")
 		b.WriteString(f.indentCTE(cte.Select))
-		// close paren with comma separator between CTEs
-		if i < len(s.CTEs)-1 && f.cfg.CommaStyle == config.CommaTrailing {
+		if i < len(ctes)-1 && f.cfg.CommaStyle == config.CommaTrailing {
 			b.WriteString("\n),\n")
 		} else {
 			b.WriteString("\n)\n")
 		}
 	}
+}
+
+func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
+	ind := f.indent()
+	var b strings.Builder
+
+	// WITH clause (CTEs)
+	f.writeCTEList(&b, s.CTEs, s.Recursive)
 
 	// SELECT [DISTINCT] [TOP (...) [PERCENT] [WITH TIES]]
 	if s.Distinct {

--- a/internal/formatter/testdata/with-dml.input.sql
+++ b/internal/formatter/testdata/with-dml.input.sql
@@ -1,0 +1,11 @@
+WITH ranked AS (SELECT order_id, ROW_NUMBER() OVER (ORDER BY created_at) AS rn FROM orders AS o)
+INSERT INTO archive (order_id) SELECT order_id FROM ranked AS r WHERE r.rn > 1000;
+
+WITH latest AS (SELECT customer_id, MAX(order_date) AS last_order FROM orders AS o GROUP BY customer_id)
+UPDATE c SET c.last_order_date = latest.last_order FROM customers AS c INNER JOIN latest ON c.customer_id = latest.customer_id;
+
+WITH old_orders AS (SELECT order_id FROM orders AS o WHERE o.created_at < '2020-01-01')
+DELETE FROM orders WHERE order_id IN (SELECT order_id FROM old_orders);
+
+WITH a AS (SELECT id FROM t1 AS t), b AS (SELECT id FROM t2 AS t)
+INSERT INTO result (id) SELECT id FROM a UNION ALL SELECT id FROM b;

--- a/internal/formatter/testdata/with-dml.sql
+++ b/internal/formatter/testdata/with-dml.sql
@@ -1,0 +1,80 @@
+with ranked as
+(
+	select
+		order_id
+	,	row_number() over (order by created_at) as rn
+	from
+		orders as o
+)
+insert into archive
+(
+	order_id
+)
+select
+	order_id
+from
+	ranked as r
+where
+	r.rn > 1000;
+
+with latest as
+(
+	select
+		customer_id
+	,	max(order_date) as last_order
+	from
+		orders as o
+	group by
+		customer_id
+)
+update
+	c
+set
+	c.last_order_date = latest.last_order
+from
+	customers as c
+inner join
+	latest
+		on c.customer_id = latest.customer_id;
+
+with old_orders as
+(
+	select
+		order_id
+	from
+		orders as o
+	where
+		o.created_at < '2020-01-01'
+)
+delete from
+	orders
+where
+	order_id in (select order_id from old_orders);
+
+with a as
+(
+	select
+		id
+	from
+		t1 as t
+)
+, b as
+(
+	select
+		id
+	from
+		t2 as t
+)
+insert into result
+(
+	id
+)
+select
+	id
+from
+	a
+union all
+select
+	id
+from
+	b;

--- a/internal/parser/ast_dml.go
+++ b/internal/parser/ast_dml.go
@@ -14,6 +14,7 @@ type OutputClause struct {
 
 // DeleteStmt represents: DELETE [TOP (n)] [<alias>] FROM <table> [AS <alias>] [OUTPUT …] [WHERE <predicate>]
 type DeleteStmt struct {
+	CTEs          []CTEDef      // WITH clause; nil if no CTEs
 	Top           string        // expression inside TOP(n); empty if absent
 	Table         string        // table name
 	Alias         string        // table alias; empty if none
@@ -30,6 +31,7 @@ func (*DeleteStmt) statementNode() {}
 // or INSERT INTO <table> [(cols)] [OUTPUT …] <select>.
 // Exactly one of Values or Select is non-nil.
 type InsertStmt struct {
+	CTEs    []CTEDef // WITH clause; nil if no CTEs
 	Table   string
 	Columns []string      // target column list; nil if no explicit column list
 	Output  *OutputClause // OUTPUT clause; nil if absent
@@ -65,6 +67,7 @@ type UpdateFromSource struct {
 // When From is non-nil the statement is SQL Server style: Target is the alias
 // that appears after UPDATE, and From holds the FROM clause details.
 type UpdateStmt struct {
+	CTEs   []CTEDef          // WITH clause; nil if no CTEs
 	Top    string            // expression inside TOP(n); empty if absent
 	Target string            // table name (ANSI) or alias (SQL Server)
 	Sets   []UpdateSet       // SET assignments; always non-empty

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -765,19 +765,45 @@ func (p *parser) parseWithSelect() (Statement, error) {
 		return nil, err
 	}
 
-	if !p.curKeyword("SELECT") {
+	switch {
+	case p.curKeyword("SELECT"):
+		stmt, err := p.parseSelectCore()
+		if err != nil {
+			return nil, err
+		}
+		stmt.CTEs = ctes
+		stmt.Recursive = recursive
+		p.consumeSemicolon()
+		return stmt, nil
+
+	case p.curKeyword("INSERT"):
+		raw, err := p.parseInsert()
+		if err != nil {
+			return nil, err
+		}
+		raw.(*InsertStmt).CTEs = ctes
+		return raw, nil
+
+	case p.curKeyword("UPDATE"):
+		raw, err := p.parseUpdate()
+		if err != nil {
+			return nil, err
+		}
+		raw.(*UpdateStmt).CTEs = ctes
+		return raw, nil
+
+	case p.curKeyword("DELETE"):
+		raw, err := p.parseDelete()
+		if err != nil {
+			return nil, err
+		}
+		raw.(*DeleteStmt).CTEs = ctes
+		return raw, nil
+
+	default:
 		return nil, fmt.Errorf(
-			"expected SELECT after WITH clause at %d:%d, got %s %q",
+			"expected SELECT, INSERT, UPDATE, or DELETE after WITH clause at %d:%d, got %s %q",
 			p.cur.Line, p.cur.Column, p.cur.Type, p.cur.Value,
 		)
 	}
-	stmt, err := p.parseSelectCore()
-	if err != nil {
-		return nil, err
-	}
-	stmt.CTEs = ctes
-	stmt.Recursive = recursive
-
-	p.consumeSemicolon()
-	return stmt, nil
 }


### PR DESCRIPTION
## Summary

- `CTEs []CTEDef` field added to `InsertStmt`, `UpdateStmt`, and `DeleteStmt`
- `parseWithSelect` extended from a SELECT-only check into a `switch` on the post-CTE keyword; INSERT, UPDATE, and DELETE each call their existing parser and receive the CTE slice via type assertion
- CTE rendering loop extracted from `formatSelectStmt` into a shared `writeCTEList(b, ctes, recursive)` helper; each DML formatter calls it at the top (no-op when CTEs is nil, so existing behaviour is unchanged)
- Golden files: `with-dml.input.sql` / `with-dml.sql` covering WITH…INSERT, WITH…UPDATE, WITH…DELETE, and multi-CTE WITH…INSERT

Closes #152

## Test plan

- [ ] `go test ./...` passes
- [ ] `TestFormatGolden/with-dml` covers all four cases
- [ ] `TestFormatIdempotent` confirms golden file is stable
- [ ] Existing SELECT/INSERT/UPDATE/DELETE golden tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)