### PR TITLE
feat: empty-catch, catch-without-throw, and exec-named-params lint rules

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ const (
 	RuleMustBeOnlyStatement         = "must-be-only-statement-in-batch"
 	RuleEmptyCatch                  = "empty-catch"
 	RuleCatchWithoutThrow           = "catch-without-throw"
+	RuleExecNamedParams             = "exec-named-params"
 )
 
 // knownRules is the set of valid lint rule names for config validation.
@@ -97,6 +98,7 @@ var knownRules = map[string]bool{
 	RuleMustBeOnlyStatement:         true,
 	RuleEmptyCatch:                  true,
 	RuleCatchWithoutThrow:           true,
+	RuleExecNamedParams:             true,
 }
 
 // Config holds all formatting and linting options for sqlfmt.

--- a/internal/linter/lint_proc.go
+++ b/internal/linter/lint_proc.go
@@ -2,10 +2,57 @@ package linter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rpf3/sqlfmt/internal/config"
 	"github.com/rpf3/sqlfmt/internal/parser"
 )
+
+// splitArgs splits a raw EXEC argument string on depth-0 commas (commas not
+// inside parentheses). Returns nil when s is empty.
+func splitArgs(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				parts = append(parts, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, strings.TrimSpace(s[start:]))
+	return parts
+}
+
+// checkExecStmt applies lint rules to an EXEC statement.
+func (l *linter) checkExecStmt(s *parser.ExecStmt) {
+	// Dynamic SQL and no-arg calls are exempt.
+	if s.Proc == "" || s.Args == "" {
+		return
+	}
+	args := splitArgs(s.Args)
+	// Single positional arg is a common convention with no ordering ambiguity.
+	if len(args) <= 1 {
+		return
+	}
+	for _, arg := range args {
+		if !strings.Contains(arg, "=") {
+			l.warn(config.RuleExecNamedParams,
+				fmt.Sprintf("exec %s: use named parameters (@param = value) instead of positional arguments", s.Proc))
+			return
+		}
+	}
+}
 
 // checkCreateProc applies lint rules to a CREATE PROCEDURE statement.
 func (l *linter) checkCreateProc(s *parser.CreateProcStmt) {

--- a/internal/linter/lint_proc_test.go
+++ b/internal/linter/lint_proc_test.go
@@ -96,3 +96,47 @@ end catch;`,
 		})
 	}
 }
+
+func TestLintExecNamedParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantRule string
+	}{
+		{
+			name:     "positional args warn",
+			input:    `exec dbo.usp_GetOrders 42, 'active';`,
+			wantRule: config.RuleExecNamedParams,
+		},
+		{
+			name:     "named params are clean",
+			input:    `exec dbo.usp_GetOrders @customer_id = 42, @status = 'active';`,
+			wantRule: "",
+		},
+		{
+			name:     "single positional arg is exempt",
+			input:    `exec dbo.usp_ProcessOrder 99;`,
+			wantRule: "",
+		},
+		{
+			name:     "single named arg is clean",
+			input:    `exec dbo.usp_ProcessOrder @order_id = 99;`,
+			wantRule: "",
+		},
+		{
+			name:     "no args is clean",
+			input:    `exec dbo.usp_ArchiveOldOrders;`,
+			wantRule: "",
+		},
+		{
+			name:     "dynamic sql is exempt",
+			input:    `exec (@sql);`,
+			wantRule: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkRule(t, tt.input, tt.wantRule)
+		})
+	}
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -161,6 +161,8 @@ func (l *linter) checkStatement(stmt parser.Statement) {
 		l.checkCreateFunc(s)
 	case *parser.TryCatchStmt:
 		l.checkTryCatch(s)
+	case *parser.ExecStmt:
+		l.checkExecStmt(s)
 	}
 	l.checkSchemaQualification(stmt)
 	l.checkIdentsWithSpaces(stmt)


### PR DESCRIPTION
## Summary

Three new lint rules, each as a separate commit:

- **`empty-catch`** (#200) — fires when `len(CatchBody) == 0`; an empty CATCH silently swallows every error the TRY block raises
- **`catch-without-throw`** (#201) — fires when no `ThrowStmt` is reachable anywhere in the CATCH body; `containsThrow` recurses into `IfStmt`, `WhileStmt`, and nested `TryCatchStmt` bodies. Skips the check when `empty-catch` already fired to avoid a redundant second warning. Known limitation: `RAISERROR` is still a `RawStmt` and is not detected as a re-raise (tracked in #217)
- **`exec-named-params`** (#204) — fires when an `EXEC` call with two or more arguments uses positional rather than named (`@param = value`) parameters. Dynamic SQL (`Proc == ""`), no-arg calls, and single-arg calls are exempt. Uses a local `splitArgs` helper that splits on depth-0 commas without crossing into the formatter package

All three rules are registered in `config.go` (`knownRules`) and dispatched from `checkStatement`. Tests live in the new `lint_proc_test.go`.

Closes #200, #201, #204

## Test plan

- [ ] `go test ./...` passes
- [ ] `TestLintEmptyCatch` covers empty and non-empty CATCH bodies
- [ ] `TestLintCatchWithoutThrow` covers direct THROW, nested THROW in IF, and empty-catch priority
- [ ] `TestLintExecNamedParams` covers positional, named, single-arg, no-arg, and dynamic-SQL cases
- [ ] `task fmt && task vet && task lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)