### PR TITLE
refactor: remove LIMIT clause

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,6 @@ const (
 	RuleIndexDirection              = "index-direction"
 	RuleOrderByDirection            = "order-by-direction"
 	RuleAliasWithoutAs              = "alias-without-as"
-	RuleNoLimit                     = "no-limit"
 	RuleOffsetRows                  = "offset-rows"
 	RuleExistsSelectOne             = "exists-select-one"
 	RuleDeleteWithoutWhere          = "delete-without-where"
@@ -80,7 +79,6 @@ var knownRules = map[string]bool{
 	RuleIndexDirection:              true,
 	RuleOrderByDirection:            true,
 	RuleAliasWithoutAs:              true,
-	RuleNoLimit:                     true,
 	RuleOffsetRows:                  true,
 	RuleExistsSelectOne:             true,
 	RuleDeleteWithoutWhere:          true,

--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -264,12 +264,6 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		b.WriteString("\n" + ind + s.Fetch + " " + f.kw("rows only"))
 	}
 
-	// LIMIT n (non-ANSI; lint rule #35 warns about this)
-	if s.Limit != "" {
-		b.WriteString("\n" + f.kw("limit"))
-		b.WriteString("\n" + ind + s.Limit)
-	}
-
 	b.WriteString(";")
 	return b.String()
 }

--- a/internal/lexer/keywords.go
+++ b/internal/lexer/keywords.go
@@ -14,7 +14,6 @@ var keywords = map[string]bool{
 	"BY":        true,
 	"HAVING":    true,
 	"ORDER":     true,
-	"LIMIT":     true,
 	"OFFSET":    true,
 	"UNION":     true,
 	"INTERSECT": true,

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -459,7 +459,7 @@ func TestTokenizeSelectKeywords(t *testing.T) {
 		"SELECT", "DISTINCT", "FROM", "WHERE", "AS",
 		"GROUP", "BY", "HAVING", "ORDER", "ASC", "DESC",
 		// Row limiting
-		"OFFSET", "ROWS", "ROW", "FETCH", "NEXT", "FIRST", "ONLY", "LIMIT",
+		"OFFSET", "ROWS", "ROW", "FETCH", "NEXT", "FIRST", "ONLY",
 		// Joins
 		"JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CROSS",
 		"ON", "USING",

--- a/internal/linter/lint_select.go
+++ b/internal/linter/lint_select.go
@@ -88,12 +88,6 @@ func (l *linter) checkSelectStmt(s *parser.SelectStmt) {
 		}
 	}
 
-	// #35 no-limit
-	if s.Limit != "" {
-		l.warn(config.RuleNoLimit,
-			"LIMIT is non-ANSI; use FETCH NEXT n ROWS ONLY instead")
-	}
-
 	// #36 offset-rows
 	if s.Offset != "" && !s.OffsetHasRows {
 		l.warn(config.RuleOffsetRows,

--- a/internal/linter/lint_select_test.go
+++ b/internal/linter/lint_select_test.go
@@ -123,39 +123,6 @@ func TestLintAliasWithoutAs(t *testing.T) {
 	})
 }
 
-func TestLintNoLimit(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		wantRule string
-	}{
-		{
-			name:     "LIMIT warns",
-			input:    `select id from orders as o limit 10;`,
-			wantRule: "no-limit",
-		},
-		{
-			name:     "FETCH NEXT is clean",
-			input:    `select id from dbo.orders as o fetch next 10 rows only;`,
-			wantRule: "",
-		},
-		{
-			name:     "no pagination is clean",
-			input:    `select id from dbo.orders as o;`,
-			wantRule: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			checkRule(t, tt.input, tt.wantRule)
-		})
-	}
-
-	t.Run("off suppresses warning", func(t *testing.T) {
-		checkRuleOff(t, `select id from dbo.orders as o limit 10;`, config.RuleNoLimit)
-	})
-}
-
 func TestLintOffsetRows(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -156,7 +156,6 @@ type SelectStmt struct {
 	Offset        string        // n from OFFSET n ROWS; empty if absent
 	OffsetHasRows bool          // true when ROWS or ROW keyword followed the offset value
 	Fetch         string        // n from FETCH NEXT n ROWS ONLY; empty if absent
-	Limit         string        // n from LIMIT n (non-ANSI); empty if absent
 }
 
 func (*SelectStmt) statementNode() {}

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -14,7 +14,7 @@ func (p *parser) isSetOpKeyword() bool {
 
 // parseSelectBranch parses one SELECT branch: SELECT [DISTINCT] cols FROM …
 // [JOINs] [WHERE] [GROUP BY] [HAVING]. It stops before ORDER BY, OFFSET,
-// FETCH, LIMIT, set operators (UNION/INTERSECT/EXCEPT), semicolons, and
+// FETCH, set operators (UNION/INTERSECT/EXCEPT), semicolons, and
 // closing parentheses. The ORDER BY and pagination clauses are parsed by the
 // enclosing parseSelectCore so they apply to the whole compound query.
 func (p *parser) parseSelectBranch() (*SelectStmt, error) {
@@ -80,7 +80,7 @@ func (p *parser) parseSelectBranch() (*SelectStmt, error) {
 				p.curKeyword("GROUP") || p.curKeyword("HAVING") ||
 				p.curKeyword("WINDOW") ||
 				p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
-				p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+				p.curKeyword("FETCH") ||
 				p.isSetOpKeyword() ||
 				p.curIs(lexer.Semicolon) || p.curIs(lexer.RParen)
 		}
@@ -116,7 +116,7 @@ func (p *parser) parseSelectBranch() (*SelectStmt, error) {
 		stmt.Having = p.parseAndChain(func() bool {
 			return p.curKeyword("WINDOW") ||
 				p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
-				p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+				p.curKeyword("FETCH") ||
 				p.isSetOpKeyword() ||
 				p.curIs(lexer.Semicolon) || p.curIs(lexer.RParen)
 		})
@@ -236,15 +236,6 @@ func (p *parser) parseSelectCore() (*SelectStmt, error) {
 		if p.curKeyword("ONLY") {
 			p.advance()
 		}
-	}
-
-	if p.curKeyword("LIMIT") {
-		p.advance()
-		tok, err := p.expect(lexer.IntLit)
-		if err != nil {
-			return nil, err
-		}
-		stmt.Limit = tok.Value
 	}
 
 	return stmt, nil
@@ -468,7 +459,7 @@ func (p *parser) parseGroupByItem() (GroupByItem, error) {
 		return p.curIs(lexer.Comma) || p.curKeyword("HAVING") ||
 			p.curKeyword("WINDOW") ||
 			p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
-			p.curKeyword("FETCH") || p.curKeyword("LIMIT") ||
+			p.curKeyword("FETCH") ||
 			p.isSetOpKeyword() ||
 			p.curIs(lexer.Semicolon)
 	}

--- a/internal/parser/parse_select_test.go
+++ b/internal/parser/parse_select_test.go
@@ -138,17 +138,6 @@ func TestParseSelectOffsetFetch(t *testing.T) {
 	}
 }
 
-func TestParseSelectLimit(t *testing.T) {
-	stmt := parseSelect(t, "select * from orders limit 10;")
-
-	if stmt.Limit != "10" {
-		t.Errorf("Limit: got %q, want %q", stmt.Limit, "10")
-	}
-	if stmt.Fetch != "" {
-		t.Errorf("Fetch: got %q, want empty", stmt.Fetch)
-	}
-}
-
 func TestParseSelectWindowFunction(t *testing.T) {
 	stmt := parseSelect(t,
 		"select t.id, row_number() over (partition by t.customer_id order by t.created_at desc) as rn from orders as t;",


### PR DESCRIPTION
## Summary

Removes `LIMIT` clause support. `LIMIT` is MySQL/PostgreSQL syntax with no T-SQL equivalent — T-SQL uses `TOP (n)` or `OFFSET n ROWS FETCH NEXT n ROWS ONLY`, both already supported. sqlfmt now produces a parse error on `LIMIT` inputs rather than formatting them.

The `no-limit` lint rule (introduced in #35) is also removed. It existed to warn users toward the ANSI alternative; that guidance is now enforced at parse time. Any `.sqlfmt.yml` with `no-limit` configured will receive an unknown-rule validation error after upgrading and the entry should be removed.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)