### PR TITLE
ci: add test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,15 @@ jobs:
         run: task vet
 
       - name: test
-        run: task test
+        run: go test -coverprofile=coverage.out -covermode=count -coverpkg=./... ./...
+
+      - name: coverage summary
+        run: |
+          go tool cover -func=coverage.out | tee coverage-summary.txt
+          echo '## Test Coverage' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat coverage-summary.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
## Summary

Replaces the bare `task test` step in CI with a coverage-instrumented run. Per-function coverage is posted to the job summary tab on every CI run (PRs and main pushes), making it visible inline without leaving GitHub.

- `go test -coverprofile=coverage.out -covermode=count -coverpkg=./... ./...` — instruments all packages for accurate cross-package coverage
- `go tool cover -func` output is appended to `$GITHUB_STEP_SUMMARY`
- `task test` continues to work locally unchanged

Trend tracking over time is deferred to #237.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)