### PR TITLE
ci: add grouped changelog to GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,24 @@ checksum:
 
 changelog:
   sort: asc
+  use: git
+  groups:
+    - title: Features
+      regexp: '^feat:'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix:'
+      order: 1
+    - title: Refactoring
+      regexp: '^refactor:'
+      order: 2
+    - title: Documentation
+      regexp: '^docs:'
+      order: 3
+    - title: CI
+      regexp: '^ci:'
+      order: 4
   filters:
     exclude:
       - "^chore:"
-      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
## Summary

Extends the existing `changelog` block in `.goreleaser.yaml` with grouped sections and explicit `use: git`, so GitHub Release notes are organised by conventional commit type rather than a flat list.

**Groups:** Features · Bug Fixes · Refactoring · Documentation · CI

**Excluded:** `chore:` and `test:` (not meaningful to users). `docs:` and `refactor:` are intentionally included — docs commits are user-facing README/scope changes, and refactor commits have carried significant user-visible work (dialect removals).

**`use: git`** is set explicitly to avoid `use: github`, which groups by PR labels rather than commit message prefixes and would produce incorrect output for this project's workflow.

No `CHANGELOG.md` is committed back to the repository — the release body is sufficient.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)