### PR TITLE
fix: remove non-T-SQL functions from builtinFunctions

### DIFF
--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -32,21 +32,20 @@ var sqlDataTypes = map[string]bool{
 var builtinFunctions = map[string]bool{
 	// Aggregate
 	"COUNT": true, "SUM": true, "AVG": true, "MAX": true, "MIN": true,
-	"STRING_AGG": true, "LISTAGG": true, "GROUP_CONCAT": true,
+	"STRING_AGG": true,
 	// Window
 	"ROW_NUMBER": true, "RANK": true, "DENSE_RANK": true, "NTILE": true,
 	"LAG": true, "LEAD": true, "FIRST_VALUE": true, "LAST_VALUE": true,
 	"CUME_DIST": true, "PERCENT_RANK": true,
 	// Null / conditional
-	"COALESCE": true, "NULLIF": true, "ISNULL": true, "NVL": true,
-	"IFNULL": true, "IIF": true,
+	"COALESCE": true, "NULLIF": true, "ISNULL": true, "IIF": true,
 	// String
 	"UPPER": true, "LOWER": true, "TRIM": true, "LTRIM": true, "RTRIM": true,
-	"LEN": true, "LENGTH": true, "SUBSTRING": true, "SUBSTR": true,
+	"LEN": true, "SUBSTRING": true,
 	"REPLACE": true, "CHARINDEX": true, "PATINDEX": true, "STUFF": true,
 	"CONCAT": true,
 	// Date / time
-	"GETDATE": true, "NOW": true, "DATEADD": true, "DATEDIFF": true,
+	"GETDATE": true, "DATEADD": true, "DATEDIFF": true,
 	"DATEPART": true, "DATENAME": true, "YEAR": true, "MONTH": true, "DAY": true,
 	"EOMONTH": true, "SYSDATETIME": true, "FORMAT": true,
 	// Type conversion (CAST is already a keyword)


### PR DESCRIPTION
## Summary

Removes seven non-T-SQL function names that were registered in `builtinFunctions` for case normalisation: `LISTAGG`, `GROUP_CONCAT`, `NVL`, `IFNULL`, `LENGTH`, `SUBSTR`, `NOW`. Each has a T-SQL equivalent already in the set (`STRING_AGG`, `ISNULL`/`COALESCE`, `LEN`, `SUBSTRING`, `GETDATE`/`SYSDATETIME`).

The impact is purely cosmetic — these names were only lowercased if encountered, not parsed or formatted specially — but registering them is inconsistent with sqlfmt's T-SQL-only scope, in the same spirit as the syntax removals in #234–#236.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)