### PR TITLE
feat: recurse linter into IF/WHILE/TRY-CATCH bodies

### DIFF
--- a/internal/linter/lint_proc_test.go
+++ b/internal/linter/lint_proc_test.go
@@ -6,6 +6,74 @@ import (
 	"github.com/rpf3/sqlfmt/internal/config"
 )
 
+// ── Control flow body recursion ───────────────────────────────────────────────
+
+func TestLintControlFlowRecursion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantRule string
+	}{
+		{
+			name: "update-without-where inside IF then branch",
+			input: `if @run = 1 begin
+	update dbo.orders set status = 'active';
+end;`,
+			wantRule: config.RuleUpdateWithoutWhere,
+		},
+		{
+			name: "update-without-where inside IF else branch",
+			input: `if @run = 1 begin
+	update dbo.orders set status = 'active' where id = 1;
+end else begin
+	update dbo.orders set status = 'inactive';
+end;`,
+			wantRule: config.RuleUpdateWithoutWhere,
+		},
+		{
+			name: "delete-without-where inside WHILE body",
+			input: `while @i < 10 begin
+	delete from dbo.logs;
+	set @i = @i + 1;
+end;`,
+			wantRule: config.RuleDeleteWithoutWhere,
+		},
+		{
+			name: "select-star inside TRY body",
+			input: `begin try
+	select * from dbo.orders as o;
+end try
+begin catch
+	throw;
+end catch;`,
+			wantRule: config.RuleSelectStar,
+		},
+		{
+			name: "update-without-where inside CATCH body",
+			input: `begin try
+	select id from dbo.orders as o;
+end try
+begin catch
+	update dbo.errors set handled = 1;
+	throw;
+end catch;`,
+			wantRule: config.RuleUpdateWithoutWhere,
+		},
+		{
+			name: "clean statements inside IF are not flagged",
+			input: `if @run = 1 begin
+	update dbo.orders set status = 'active' where id = @id;
+end;`,
+			wantRule: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkRule(t, tt.input, tt.wantRule)
+		})
+	}
+}
+
 func TestLintEmptyCatch(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -24,7 +92,7 @@ end catch;`,
 		{
 			name: "catch with throw is clean",
 			input: `begin try
-	insert into orders (customer_id) values (42);
+	insert into dbo.orders (customer_id) values (42);
 end try
 begin catch
 	rollback transaction;
@@ -49,7 +117,7 @@ func TestLintCatchWithoutThrow(t *testing.T) {
 		{
 			name: "catch without throw warns",
 			input: `begin try
-	insert into orders (customer_id) values (42);
+	insert into dbo.orders (customer_id) values (42);
 end try
 begin catch
 	rollback transaction;
@@ -59,7 +127,7 @@ end catch;`,
 		{
 			name: "catch with direct throw is clean",
 			input: `begin try
-	insert into orders (customer_id) values (42);
+	insert into dbo.orders (customer_id) values (42);
 end try
 begin catch
 	rollback transaction;
@@ -70,7 +138,7 @@ end catch;`,
 		{
 			name: "throw inside if branch satisfies rule",
 			input: `begin try
-	insert into orders (customer_id) values (42);
+	insert into dbo.orders (customer_id) values (42);
 end try
 begin catch
 	if @@trancount > 0 begin
@@ -83,7 +151,7 @@ end catch;`,
 		{
 			name: "empty catch fires empty-catch not catch-without-throw",
 			input: `begin try
-	insert into orders (customer_id) values (42);
+	insert into dbo.orders (customer_id) values (42);
 end try
 begin catch
 end catch;`,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -161,11 +161,26 @@ func (l *linter) checkStatement(stmt parser.Statement) {
 		l.checkCreateFunc(s)
 	case *parser.TryCatchStmt:
 		l.checkTryCatch(s)
+		l.checkStmtList(s.TryBody)
+		l.checkStmtList(s.CatchBody)
+	case *parser.IfStmt:
+		l.checkStmtList(s.Then)
+		l.checkStmtList(s.Else)
+	case *parser.WhileStmt:
+		l.checkStmtList(s.Body)
 	case *parser.ExecStmt:
 		l.checkExecStmt(s)
 	}
 	l.checkSchemaQualification(stmt)
 	l.checkIdentsWithSpaces(stmt)
+}
+
+// checkStmtList runs checkStatement on each statement in a slice.
+// Used to recurse into IF/WHILE/TRY-CATCH bodies.
+func (l *linter) checkStmtList(stmts []parser.Statement) {
+	for _, stmt := range stmts {
+		l.checkStatement(stmt)
+	}
 }
 
 func (l *linter) checkCreateIndex(s *parser.CreateIndexStmt) {


### PR DESCRIPTION
## Summary

Every lint rule was previously blind to statements nested inside control flow bodies — `update-without-where`, `select-star`, `missing-schema-name` etc. would all silently miss code inside `IF`, `WHILE`, and `TRY/CATCH` blocks.

**Fix:** adds `checkStmtList([]Statement)` helper and three new cases in `checkStatement`:

- `IfStmt` → recurse into `Then` and `Else`
- `WhileStmt` → recurse into `Body`
- `TryCatchStmt` → existing `checkTryCatch` (empty-catch/catch-without-throw) **plus** recurse into `TryBody` and `CatchBody`

Because `checkStatement` already calls `checkSchemaQualification` and `checkIdentsWithSpaces` on every statement it visits, those checks are now applied inside control flow bodies for free — no extra wiring needed.

**Test impact:** Existing `TestLintEmptyCatch` and `TestLintCatchWithoutThrow` tests used unqualified `orders` in TRY body inserts. The recursion now correctly fires `missing-schema-name` on those statements, so the tests were updated to use `dbo.orders`.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)