### PR TITLE
ci: include version in release archive filenames

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
 
 archives:
   - formats: [tar.gz]
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
         formats: [zip]


### PR DESCRIPTION
## Summary

Adds `{{ .Version }}` to the GoReleaser `name_template` so release archives are named `sqlfmt_1.0.0_darwin_arm64.tar.gz` rather than `sqlfmt_darwin_arm64.tar.gz`.

This is the conventional GoReleaser naming pattern and ensures downloaded archives are uniquely named across releases — useful when users manually save multiple versions. Also required for `install.sh` (#87) to construct unambiguous download URLs.

v1.0.0 will be re-cut after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)