### PR TITLE
feat: parse and format table hints (WITH (NOLOCK) etc.)

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -144,6 +144,9 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		if s.From.Alias != "" {
 			b.WriteString(" " + f.kw("as") + " " + f.ident(s.From.Alias))
 		}
+		if s.From.Hints != "" {
+			b.WriteString(" " + f.kw("with") + " " + strings.ToLower(s.From.Hints))
+		}
 	}
 
 	// JOINs
@@ -164,6 +167,9 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 			}
 			if jc.Alias != "" {
 				b.WriteString(" " + f.kw("as") + " " + f.ident(jc.Alias))
+			}
+			if jc.Hints != "" {
+				b.WriteString(" " + f.kw("with") + " " + strings.ToLower(jc.Hints))
 			}
 			if jc.On != nil {
 				terms := parser.AndTerms(jc.On)

--- a/internal/formatter/testdata/select.input.sql
+++ b/internal/formatter/testdata/select.input.sql
@@ -23,3 +23,7 @@ SELECT t.id,t.name FROM orders AS t WHERE t.status = 'active' AND t.region = 'us
 SELECT t.status,count(*) AS order_count FROM orders AS t GROUP BY t.status HAVING count(*) > 10 AND sum(t.amount) > 1000;
 SELECT o.id,o.status FROM orders AS o INNER JOIN customers AS c ON c.id = o.customer_id AND c.active = 1 WHERE o.status = 'active' AND o.total_amount > 0;
 SELECT COUNT(*) AS total,SUM(t.amount) AS revenue,AVG(t.amount) AS avg_amount FROM orders AS t;
+SELECT t.id,t.status FROM orders AS t WITH (NOLOCK);
+SELECT t.id,t.status FROM orders t WITH (NOLOCK);
+SELECT o.id,c.name FROM orders AS o WITH (NOLOCK) INNER JOIN customers AS c WITH (NOLOCK) ON c.id = o.customer_id;
+SELECT t.id FROM orders AS t WITH (ROWLOCK, UPDLOCK);

--- a/internal/formatter/testdata/select.sql
+++ b/internal/formatter/testdata/select.sql
@@ -303,3 +303,29 @@ select
 ,	avg(t.amount) as avg_amount
 from
 	orders as t;
+
+select
+	t.id
+,	t.status
+from
+	orders as t with (nolock);
+
+select
+	t.id
+,	t.status
+from
+	orders as t with (nolock);
+
+select
+	o.id
+,	c.name
+from
+	orders as o with (nolock)
+inner join
+	customers as c with (nolock)
+		on c.id = o.customer_id;
+
+select
+	t.id
+from
+	orders as t with (rowlock, updlock);

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -53,6 +53,7 @@ const (
 type JoinClause struct {
 	Type          JoinType
 	Name          string      // joined table name; empty for APPLY subquery sources
+	Hints         string      // table hints e.g. "(nolock)"; empty if none
 	Alias         string      // table alias; empty if none
 	AliasExplicit bool        // true when the AS keyword preceded the alias
 	On            Expr        // ON condition; nil for CROSS
@@ -123,6 +124,7 @@ type GroupByItem struct {
 // Exactly one of Name (a table name) or Subquery is non-zero.
 type SelectFromSource struct {
 	Name          string       // table name; empty for a subquery
+	Hints         string       // table hints e.g. "(nolock)"; empty if none
 	Subquery      *SelectStmt  // derived table; nil for a named table
 	Alias         string       // alias for either kind; empty if no alias
 	AliasExplicit bool         // true when the AS keyword preceded the alias

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -349,6 +349,17 @@ func (p *parser) parseFromSource() (SelectFromSource, error) {
 		p.advance()
 	}
 
+	// Optional table hints: [[AS] alias] WITH (hint, ...)
+	// Hints follow the alias per the T-SQL grammar.
+	if p.curKeyword("WITH") && p.peek.Type == lexer.LParen {
+		p.advance() // consume WITH
+		hints, err := p.parseParenRaw()
+		if err != nil {
+			return SelectFromSource{}, err
+		}
+		source.Hints = hints
+	}
+
 	return source, nil
 }
 
@@ -652,6 +663,17 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 		} else if p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent) {
 			jc.Alias = p.cur.Value
 			p.advance()
+		}
+
+		// Optional table hints: [[AS] alias] WITH (hint, ...)
+		// Hints follow the alias per the T-SQL grammar.
+		if p.curKeyword("WITH") && p.peek.Type == lexer.LParen {
+			p.advance() // consume WITH
+			hints, err := p.parseParenRaw()
+			if err != nil {
+				return nil, err
+			}
+			jc.Hints = hints
 		}
 
 		// ON condition or USING column list


### PR DESCRIPTION
## Summary

- Adds `Hints string` to `SelectFromSource` and `JoinClause` AST structs
- Parses `WITH (...)` table hints on FROM sources and JOIN targets, following the T-SQL grammar order: hints come **after** the alias
- Normalises hint content to lowercase, consistent with keyword formatting
- Supports multiple hints: `WITH (ROWLOCK, UPDLOCK)` preserved verbatim via the existing `parseParenRaw` helper

**Example:**
```sql
-- input
SELECT o.id,c.name FROM orders AS o WITH (NOLOCK) INNER JOIN customers AS c WITH (NOLOCK) ON c.id = o.customer_id;
```
```sql
-- output
select
	o.id
,	c.name
from
	orders as o with (nolock)
inner join
	customers as c with (nolock)
		on c.id = o.customer_id;
```

Closes #163

## Test plan

- [ ] `WITH (NOLOCK)` on FROM source with AS alias
- [ ] `WITH (NOLOCK)` on FROM source with bare alias
- [ ] `WITH (NOLOCK)` on JOIN target
- [ ] Multiple hints `WITH (ROWLOCK, UPDLOCK)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)