### PR TITLE
feat: add JSON functions to builtinFunctions for case normalisation

### DIFF
--- a/internal/formatter/format_select_test.go
+++ b/internal/formatter/format_select_test.go
@@ -443,6 +443,53 @@ func TestFormatSelectWindowFunctionIdempotent(t *testing.T) {
 	}
 }
 
+// TestFormatSelectJSONFunctions verifies that SQL Server 2016+ JSON functions
+// are lowercased and have no space before their opening parenthesis.
+func TestFormatSelectJSONFunctions(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "JSON_VALUE in SELECT list",
+			input: "SELECT JSON_VALUE(doc, '$.name') AS name FROM t;",
+			want:  "select\n\tjson_value(doc, '$.name') as name\nfrom\n\tt;\n",
+		},
+		{
+			name:  "JSON_QUERY in SELECT list",
+			input: "SELECT JSON_QUERY(doc, '$.address') AS addr FROM t;",
+			want:  "select\n\tjson_query(doc, '$.address') as addr\nfrom\n\tt;\n",
+		},
+		{
+			name:  "JSON_MODIFY in SELECT list",
+			input: "SELECT JSON_MODIFY(doc, '$.name', 'new') AS updated FROM t;",
+			want:  "select\n\tjson_modify(doc, '$.name', 'new') as updated\nfrom\n\tt;\n",
+		},
+		{
+			name:  "ISJSON in WHERE clause",
+			input: "SELECT id FROM t WHERE ISJSON(doc) = 1;",
+			want:  "select\n\tid\nfrom\n\tt\nwhere\n\tisjson(doc) = 1;\n",
+		},
+		{
+			name:  "JSON_PATH_EXISTS in WHERE clause",
+			input: "SELECT id FROM t WHERE JSON_PATH_EXISTS(doc, '$.name') = 1;",
+			want:  "select\n\tid\nfrom\n\tt\nwhere\n\tjson_path_exists(doc, '$.name') = 1;\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Format(tc.input, config.Default())
+			if err != nil {
+				t.Fatalf("Format() error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Format() mismatch:\ngot:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestFormatSelectIIF verifies that IIF is lowercased and has no space before
 // its opening parenthesis. IIF tokenises as Ident (not a Keyword), so the
 // Ident → LParen branch in needsSelectSpace already suppresses the space

--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -54,6 +54,9 @@ var builtinFunctions = map[string]bool{
 	// Numeric
 	"ROUND": true, "FLOOR": true, "CEILING": true,
 	"ABS": true, "POWER": true, "SQRT": true, "SIGN": true,
+	// JSON (SQL Server 2016+)
+	"JSON_VALUE": true, "JSON_QUERY": true, "JSON_MODIFY": true,
+	"ISJSON": true, "JSON_PATH_EXISTS": true,
 }
 
 // exprToken returns the normalised string for a single expression token:


### PR DESCRIPTION
`JSON_VALUE`, `JSON_QUERY`, `JSON_MODIFY`, `ISJSON`, and `JSON_PATH_EXISTS` are mainstream T-SQL (SQL Server 2016+) but were absent from `builtinFunctions`, leaving them in whatever case the user wrote them rather than normalising to lowercase.

All five tokenise as `Ident` (not `Keyword`), so spacing before their opening parenthesis was already correct — only case normalisation was missing. The `isFunctionKeyword()` addition mentioned in the issue would have been dead code for the same reason as `IIF` (#267).

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)