### PR TITLE
feat: parse and format FOR XML and FOR JSON clauses

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -292,6 +292,18 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		b.WriteString("\n" + ind + s.Fetch + " " + f.kw("rows only"))
 	}
 
+	// FOR XML / FOR JSON
+	if s.ForKind != parser.ForNone {
+		if s.ForKind == parser.ForXML {
+			b.WriteString("\n" + f.kw("for xml"))
+		} else {
+			b.WriteString("\n" + f.kw("for json"))
+		}
+		if s.ForOpts != "" {
+			b.WriteString("\n" + ind + strings.ToLower(s.ForOpts))
+		}
+	}
+
 	b.WriteString(";")
 	return b.String()
 }

--- a/internal/formatter/testdata/for-xml-json.input.sql
+++ b/internal/formatter/testdata/for-xml-json.input.sql
@@ -1,0 +1,17 @@
+-- FOR XML PATH with ROOT
+SELECT order_id, status FROM dbo.orders AS o FOR XML PATH('order'), ROOT('orders');
+
+-- FOR XML AUTO with ELEMENTS
+SELECT order_id, status FROM dbo.orders AS o FOR XML AUTO, ELEMENTS;
+
+-- FOR XML RAW with ROOT and ELEMENTS XSINIL
+SELECT order_id, status FROM dbo.orders AS o FOR XML RAW('row'), ROOT('data'), ELEMENTS XSINIL;
+
+-- FOR JSON PATH with ROOT
+SELECT order_id, status FROM dbo.orders AS o FOR JSON PATH, ROOT('orders');
+
+-- FOR JSON AUTO (no options)
+SELECT order_id, status FROM dbo.orders AS o FOR JSON AUTO;
+
+-- FOR XML after ORDER BY
+SELECT order_id, status FROM dbo.orders AS o ORDER BY order_id ASC FOR XML PATH('order');

--- a/internal/formatter/testdata/for-xml-json.sql
+++ b/internal/formatter/testdata/for-xml-json.sql
@@ -1,0 +1,49 @@
+select
+	order_id
+,	status
+from
+	dbo.orders as o
+for xml
+	path('order'), root('orders');
+
+select
+	order_id
+,	status
+from
+	dbo.orders as o
+for xml
+	auto, elements;
+
+select
+	order_id
+,	status
+from
+	dbo.orders as o
+for xml
+	raw('row'), root('data'), elements xsinil;
+
+select
+	order_id
+,	status
+from
+	dbo.orders as o
+for json
+	path, root('orders');
+
+select
+	order_id
+,	status
+from
+	dbo.orders as o
+for json
+	auto;
+
+select
+	order_id
+,	status
+from
+	dbo.orders as o
+order by
+	order_id asc
+for xml
+	path('order');

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -131,6 +131,15 @@ type SelectFromSource struct {
 	Pivot         *PivotClause // non-nil when a PIVOT or UNPIVOT operator follows the named source
 }
 
+// ForClauseKind identifies whether a FOR clause is FOR XML or FOR JSON.
+type ForClauseKind int
+
+const (
+	ForNone ForClauseKind = iota // no FOR clause
+	ForXML                       // FOR XML ...
+	ForJSON                      // FOR JSON ...
+)
+
 // SelectStmt represents a [WITH ...] SELECT statement.
 //
 // WHERE representation: exactly one of Where or WhereSubq is non-nil.
@@ -159,6 +168,8 @@ type SelectStmt struct {
 	Offset        string        // n from OFFSET n ROWS; empty if absent
 	OffsetHasRows bool          // true when ROWS or ROW keyword followed the offset value
 	Fetch         string        // n from FETCH NEXT n ROWS ONLY; empty if absent
+	ForKind       ForClauseKind // ForXML or ForJSON; ForNone if absent
+	ForOpts       string        // raw options after the XML/JSON mode keyword; empty if absent
 }
 
 func (*SelectStmt) statementNode() {}

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rpf3/sqlfmt/internal/lexer"
 )
@@ -246,6 +247,41 @@ func (p *parser) parseSelectCore() (*SelectStmt, error) {
 		if p.curKeyword("ONLY") {
 			p.advance()
 		}
+	}
+
+	// FOR XML / FOR JSON — must appear after all other clauses.
+	if p.curKeyword("FOR") {
+		p.advance() // consume FOR
+		switch {
+		case p.curIs(lexer.Ident) && strings.EqualFold(p.cur.Value, "XML"):
+			stmt.ForKind = ForXML
+		case p.curIs(lexer.Ident) && strings.EqualFold(p.cur.Value, "JSON"):
+			stmt.ForKind = ForJSON
+		default:
+			return nil, fmt.Errorf(
+				"expected XML or JSON after FOR at %d:%d, got %s %q",
+				p.cur.Line, p.cur.Column, p.cur.Type, p.cur.Value,
+			)
+		}
+		p.advance() // consume XML or JSON
+		// Collect the raw options (mode keyword + any comma-separated directives)
+		// up to the terminating semicolon or a depth-0 closing paren (subquery boundary).
+		// Inner parens like PATH('order') are tracked by depth so they are included.
+		var tokBuf []lexer.Token
+		depth := 0
+		for p.cur.Type != lexer.EOF && !p.curIs(lexer.Semicolon) {
+			if p.curIs(lexer.RParen) && depth == 0 {
+				break
+			}
+			if p.curIs(lexer.LParen) {
+				depth++
+			} else if p.curIs(lexer.RParen) {
+				depth--
+			}
+			tokBuf = append(tokBuf, p.cur)
+			p.advance()
+		}
+		stmt.ForOpts = joinBodyTokens(tokBuf)
 	}
 
 	return stmt, nil
@@ -509,6 +545,7 @@ func (p *parser) parseOrderByList() ([]OrderItem, error) {
 			return p.curKeyword("ASC") || p.curKeyword("DESC") ||
 				p.curIs(lexer.Comma) ||
 				p.curKeyword("OFFSET") || p.curKeyword("FETCH") ||
+				p.curKeyword("FOR") ||
 				p.curKeyword("LIMIT") || p.curIs(lexer.Semicolon)
 		})
 		item := OrderItem{Value: expr}


### PR DESCRIPTION
## Summary

- Adds `ForClauseKind` type (`ForNone`/`ForXML`/`ForJSON`) and `ForKind`/`ForOpts` fields to `SelectStmt`
- Parses `FOR XML` and `FOR JSON` after the FETCH block in `parseSelectCore`; collects options as a raw string with paren-depth tracking so `PATH('order')` inner parens are not mistaken for subquery boundaries
- Adds `FOR` to the ORDER BY expression stop function so `col FOR XML` after ORDER BY doesn't get swallowed as a single raw expression
- Formats as `for xml`/`for json` on its own line, options indented on the next line (consistent with `into`, `from`, `order by`)

Closes #176

## Test plan

- [ ] Golden tests pass for all 6 variants: FOR XML PATH, AUTO, RAW with ELEMENTS XSINIL; FOR JSON PATH, AUTO; FOR XML after ORDER BY
- [ ] Idempotency test passes
- [ ] All existing tests unaffected
- [ ] `task fmt && task test && task vet && task lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)