### PR TITLE
fix: parse OVER win_name as structured FunctionCallExpr

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -34,6 +34,11 @@ func (f *formatter) formatExpr(e parser.Expr) string {
 		fnStr = fn.Name + "(" + strings.Join(args, ", ") + ")"
 	}
 
+	// Named window reference: render inline without a block.
+	if fn.Over.Ref != "" {
+		return fnStr + " " + f.kw("over") + " " + fn.Over.Ref
+	}
+
 	// Build OVER spec parts with keyword casing applied.
 	var overParts []string
 	if len(fn.Over.PartitionBy) > 0 {

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -22,6 +22,7 @@ type LiteralExpr struct{ Token lexer.Token }
 
 // WindowSpec holds the OVER clause of a window function call.
 type WindowSpec struct {
+	Ref         string      // named window reference (e.g. "win"); non-empty = reference form
 	PartitionBy []Expr      // PARTITION BY expressions; nil if absent
 	OrderBy     []OrderItem // ORDER BY items; nil if absent
 	FrameUnit   string      // "rows" or "range"; empty if no frame clause
@@ -89,6 +90,10 @@ func Render(e Expr) string {
 			result = v.Name + "(" + strings.Join(args, ", ") + ")"
 		}
 		if v.Over != nil {
+			if v.Over.Ref != "" {
+				result += " over " + v.Over.Ref
+				return result
+			}
 			var overParts []string
 			if len(v.Over.PartitionBy) > 0 {
 				parts := make([]string, len(v.Over.PartitionBy))

--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -203,7 +203,15 @@ func (p *parser) parseFunctionCall() *FunctionCallExpr {
 		}
 	}
 
-	// Window function: check for OVER (
+	// Named window reference: OVER win_name (no parens)
+	if p.curKeyword("OVER") && (p.peek.Type == lexer.Ident || p.peek.Type == lexer.QuotedIdent) {
+		p.advance() // consume OVER
+		ref := p.cur.Value
+		p.advance() // consume name
+		fn.Over = &WindowSpec{Ref: ref}
+		return fn
+	}
+	// Inline window spec: OVER (...)
 	if p.curKeyword("OVER") && p.peek.Type == lexer.LParen {
 		p.advance() // consume OVER
 		fn.Over = p.parseWindowSpec()


### PR DESCRIPTION
## Summary

- Adds `Ref string` to `WindowSpec` for named window references (`OVER win`)
- `parseFunctionCall` now detects `OVER ident` before the existing `OVER (` path and sets `Over.Ref` instead of falling through to `RawExpr` accumulation
- `Render()` and `formatExpr` both short-circuit on non-empty `Ref`, emitting `over name` inline — no block layout since there's no spec to spread across lines
- Formatter output for existing golden files is byte-identical; only the internal AST representation becomes correct

Previously `OVER win` was a "works by accident" case: the raw expression fallback happened to produce the right string, but the `over` keyword bypassed keyword-case config, the function wasn't recognisable as a window function in the AST, and `formatExpr` couldn't apply `f.kw("over")` to it.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)