### PR TITLE
feat: TVF calls in FROM clause and regular JOINs

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -234,6 +234,9 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 	} else {
 		b.WriteString("\n" + ind)
 		b.WriteString(f.ident(s.From.Name))
+		if s.From.TVFArgs != "" {
+			b.WriteString(s.From.TVFArgs)
+		}
 		if s.From.Pivot != nil {
 			b.WriteString(f.formatPivot(s.From.Pivot))
 		}

--- a/internal/formatter/testdata/tvf-from.input.sql
+++ b/internal/formatter/testdata/tvf-from.input.sql
@@ -1,0 +1,17 @@
+-- TVF in FROM with single argument
+SELECT t.order_id, t.total FROM dbo.fn_get_orders(@customer_id) AS t;
+
+-- TVF in FROM with multiple arguments
+SELECT dr.start_date, dr.end_date FROM dbo.fn_date_range(@start, @end) AS dr;
+
+-- TVF with no arguments (explicit empty parens)
+SELECT s.value FROM STRING_SPLIT(@csv, ',') AS s;
+
+-- TVF in FROM with schema-qualified name and no alias
+SELECT * FROM dbo.fn_active_customers() AS ac WHERE ac.region = 'US';
+
+-- TVF in regular INNER JOIN
+SELECT o.order_id, s.label FROM dbo.orders AS o INNER JOIN dbo.fn_status_labels() AS s ON o.status_code = s.code;
+
+-- Multiple TVFs: one in FROM, one in JOIN
+SELECT a.id, b.name FROM dbo.fn_accounts(@date) AS a INNER JOIN dbo.fn_names(@date) AS b ON a.id = b.id;

--- a/internal/formatter/testdata/tvf-from.sql
+++ b/internal/formatter/testdata/tvf-from.sql
@@ -1,0 +1,41 @@
+select
+	t.order_id
+,	t.total
+from
+	dbo.fn_get_orders(@customer_id) as t;
+
+select
+	dr.start_date
+,	dr.end_date
+from
+	dbo.fn_date_range(@start, @end) as dr;
+
+select
+	s.value
+from
+	STRING_SPLIT(@csv, ',') as s;
+
+select
+	*
+from
+	dbo.fn_active_customers() as ac
+where
+	ac.region = 'US';
+
+select
+	o.order_id
+,	s.label
+from
+	dbo.orders as o
+inner join
+	dbo.fn_status_labels() as s
+		on o.status_code = s.code;
+
+select
+	a.id
+,	b.name
+from
+	dbo.fn_accounts(@date) as a
+inner join
+	dbo.fn_names(@date) as b
+		on a.id = b.id;

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -124,6 +124,7 @@ type GroupByItem struct {
 // Exactly one of Name (a table name) or Subquery is non-zero.
 type SelectFromSource struct {
 	Name          string       // table name; empty for a subquery
+	TVFArgs       string       // parenthesised arg list for TVF sources e.g. "(@id)"; empty for plain tables
 	Hints         string       // table hints e.g. "(nolock)"; empty if none
 	Subquery      *SelectStmt  // derived table; nil for a named table
 	Alias         string       // alias for either kind; empty if no alias

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -373,6 +373,15 @@ func (p *parser) parseFromSource() (SelectFromSource, error) {
 	}
 	source := SelectFromSource{Name: name}
 
+	// Optional TVF argument list: name(args...)
+	if p.curIs(lexer.LParen) {
+		args, err := p.parseParenRaw()
+		if err != nil {
+			return SelectFromSource{}, err
+		}
+		source.TVFArgs = args
+	}
+
 	// Optional PIVOT / UNPIVOT postfix operator before the alias.
 	if p.curKeyword("PIVOT") || p.curKeyword("UNPIVOT") {
 		pivot, err := p.parsePivotClause()
@@ -698,6 +707,15 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 			return nil, err
 		}
 		jc := JoinClause{Type: joinType, Name: joinName}
+
+		// Optional TVF argument list: name(args...)
+		if p.curIs(lexer.LParen) {
+			args, err := p.parseParenRaw()
+			if err != nil {
+				return nil, err
+			}
+			jc.TVFArgs = args
+		}
 
 		// Optional alias (AS or bare)
 		if p.curKeyword("AS") {


### PR DESCRIPTION
## Summary

- Adds `TVFArgs string` to `SelectFromSource` (mirrors the existing field on `JoinClause` from PR #139)
- `parseFromSource()` detects `LParen` after the table name and collects args via `parseParenRaw()`
- Same detection added to the non-APPLY JOIN branch in `parseJoinClauses()`
- Formatter renders `TVFArgs` inline after the source name: `dbo.fn_get_orders(@id) as t`
- Golden-file tests cover: single arg, multiple args, empty parens, WHERE after TVF, JOIN with TVF, multiple TVFs in one query

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)