### PR TITLE
fix: lowercase system TVF names in FROM and JOIN

### DIFF
--- a/internal/formatter/testdata/tvf-from.sql
+++ b/internal/formatter/testdata/tvf-from.sql
@@ -13,7 +13,7 @@ from
 select
 	s.value
 from
-	STRING_SPLIT(@csv, ',') as s;
+	string_split(@csv, ',') as s;
 
 select
 	*

--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -57,6 +57,9 @@ var builtinFunctions = map[string]bool{
 	// JSON (SQL Server 2016+)
 	"JSON_VALUE": true, "JSON_QUERY": true, "JSON_MODIFY": true,
 	"ISJSON": true, "JSON_PATH_EXISTS": true,
+	// Table-valued functions (system)
+	"STRING_SPLIT": true, "OPENJSON": true,
+	"OPENROWSET": true, "OPENQUERY": true, "OPENXML": true, "OPENDATASOURCE": true,
 }
 
 // exprToken returns the normalised string for a single expression token:

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -380,6 +380,9 @@ func (p *parser) parseFromSource() (SelectFromSource, error) {
 			return SelectFromSource{}, err
 		}
 		source.TVFArgs = args
+		if builtinFunctions[strings.ToUpper(source.Name)] {
+			source.Name = strings.ToLower(source.Name)
+		}
 	}
 
 	// Optional PIVOT / UNPIVOT postfix operator before the alias.
@@ -715,6 +718,9 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 				return nil, err
 			}
 			jc.TVFArgs = args
+			if builtinFunctions[strings.ToUpper(jc.Name)] {
+				jc.Name = strings.ToLower(jc.Name)
+			}
 		}
 
 		// Optional alias (AS or bare)


### PR DESCRIPTION
## Summary

- Adds `STRING_SPLIT`, `OPENJSON`, `OPENROWSET`, `OPENQUERY`, `OPENXML`, `OPENDATASOURCE` to `builtinFunctions`
- After collecting `TVFArgs` in `parseFromSource()` and the regular-JOIN branch, checks the name against `builtinFunctions` and lowercases when matched
- User-defined TVFs (`dbo.fn_get_orders`) are unaffected — schema-qualified names are never in the map
- Golden file updated: `STRING_SPLIT(@csv, ',')` → `string_split(@csv, ',')`

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)