### PR TITLE
feat: add OPTION query hint clause to SELECT, INSERT, UPDATE, DELETE

### DIFF
--- a/internal/formatter/format_dml.go
+++ b/internal/formatter/format_dml.go
@@ -6,6 +6,26 @@ import (
 	"github.com/rpf3/sqlfmt/internal/parser"
 )
 
+// writeOptionClause writes an OPTION (...) clause into b, or does nothing
+// if option is empty. The keyword sits on its own line. A single hint is
+// written inline on the next line; multiple hints use a vertical paren block
+// with leading-comma style, matching how other comma lists are formatted.
+func (f *formatter) writeOptionClause(b *strings.Builder, option string) {
+	if option == "" {
+		return
+	}
+	// option is stored as "(hint1, hint2)" — strip the surrounding parens.
+	inner := strings.ToLower(option[1 : len(option)-1])
+	hints := splitDepthZeroCommas(inner)
+	b.WriteString("\n" + f.kw("option"))
+	if len(hints) == 1 {
+		ind := f.indent()
+		b.WriteString("\n" + ind + "(" + hints[0] + ")")
+	} else {
+		f.writeInListBlock(b, hints)
+	}
+}
+
 // writeOutputClause writes an OUTPUT clause into b.
 // The keyword sits on its own line; columns are indented one level via
 // writeCommaList — matching the style used for SELECT column lists.
@@ -50,9 +70,12 @@ func (f *formatter) formatInsert(s *parser.InsertStmt) string {
 	f.writeOutputClause(&b, s.Output)
 
 	if s.Select != nil {
-		b.WriteString("\n")
-		b.WriteString(f.formatSelectStmt(s.Select))
-		return b.String() // formatSelectStmt supplies the trailing ";"
+		sel := f.formatSelectStmt(s.Select)
+		sel = strings.TrimSuffix(sel, ";")
+		b.WriteString("\n" + sel)
+		f.writeOptionClause(&b, s.Option)
+		b.WriteString(";")
+		return b.String()
 	}
 
 	// VALUES form — each row is a vertical block; rows separated by trailing ","
@@ -70,6 +93,7 @@ func (f *formatter) formatInsert(s *parser.InsertStmt) string {
 			b.WriteString(",") // structural row separator, not a list comma
 		}
 	}
+	f.writeOptionClause(&b, s.Option)
 	b.WriteString(";")
 	return b.String()
 }
@@ -127,6 +151,7 @@ func (f *formatter) formatUpdate(s *parser.UpdateStmt) string {
 		b.WriteString("\n" + f.kw("where"))
 		f.writeExprPred(&b, s.Where)
 	}
+	f.writeOptionClause(&b, s.Option)
 	b.WriteString(";")
 	return b.String()
 }
@@ -170,6 +195,7 @@ func (f *formatter) formatDelete(s *parser.DeleteStmt) string {
 		b.WriteString("\n" + f.kw("where"))
 		f.writeExprPred(&b, s.Where)
 	}
+	f.writeOptionClause(&b, s.Option)
 	b.WriteString(";")
 	return b.String()
 }

--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -386,6 +386,8 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		}
 	}
 
+	f.writeOptionClause(&b, s.Option)
+
 	b.WriteString(";")
 	return b.String()
 }

--- a/internal/formatter/testdata/delete.input.sql
+++ b/internal/formatter/testdata/delete.input.sql
@@ -2,3 +2,5 @@ DELETE o FROM orders AS o WHERE o.status = 'cancelled' AND o.created_at < '2024-
 DELETE s FROM sessions AS s;
 DELETE FROM archive WHERE created_at < '2020-01-01';
 DELETE FROM staging;
+
+DELETE FROM orders WHERE status = 'cancelled' OPTION (RECOMPILE);

--- a/internal/formatter/testdata/delete.sql
+++ b/internal/formatter/testdata/delete.sql
@@ -17,3 +17,10 @@ where
 	created_at < '2020-01-01';
 
 delete from staging;
+
+delete from
+	orders
+where
+	status = 'cancelled'
+option
+	(recompile);

--- a/internal/formatter/testdata/insert.input.sql
+++ b/internal/formatter/testdata/insert.input.sql
@@ -7,3 +7,7 @@ INSERT INTO orders (id,customer_id,total) VALUES (1,42,99.99),(2,43,149.99);
 INSERT INTO order_archive SELECT id, customer_id FROM orders;
 
 INSERT INTO order_archive SELECT id, customer_id FROM orders WHERE created_at < '2024-01-01';
+
+INSERT INTO orders (id, customer_id) VALUES (1, 42) OPTION (RECOMPILE);
+
+INSERT INTO order_archive SELECT id, customer_id FROM orders OPTION (HASH JOIN);

--- a/internal/formatter/testdata/insert.sql
+++ b/internal/formatter/testdata/insert.sql
@@ -52,3 +52,25 @@ from
 	orders
 where
 	created_at < '2024-01-01';
+
+insert into orders
+(
+	id
+,	customer_id
+)
+values
+(
+	1
+,	42
+)
+option
+	(recompile);
+
+insert into order_archive
+select
+	id
+,	customer_id
+from
+	orders
+option
+	(hash join);

--- a/internal/formatter/testdata/select.input.sql
+++ b/internal/formatter/testdata/select.input.sql
@@ -31,3 +31,9 @@ SELECT @total = count(*) FROM orders AS t WHERE t.status = 'active';
 SELECT @min = min(t.amount),@max = max(t.amount) FROM orders AS t;
 SELECT @name = t.name FROM customers AS t WHERE t.id = @id;
 SELECT @count = 0,@status = 'pending';
+
+SELECT t.col1 FROM dbo.t OPTION (RECOMPILE);
+
+SELECT t.col1 FROM dbo.t OPTION (MAXDOP 4, RECOMPILE);
+
+SELECT t.col1 FROM dbo.t WHERE t.id = 1 OPTION (RECOMPILE);

--- a/internal/formatter/testdata/select.sql
+++ b/internal/formatter/testdata/select.sql
@@ -359,3 +359,29 @@ where
 select
 	@count = 0
 ,	@status = 'pending';
+
+select
+	t.col1
+from
+	dbo.t
+option
+	(recompile);
+
+select
+	t.col1
+from
+	dbo.t
+option
+	(
+		maxdop 4
+	,	recompile
+	);
+
+select
+	t.col1
+from
+	dbo.t
+where
+	t.id = 1
+option
+	(recompile);

--- a/internal/formatter/testdata/update.input.sql
+++ b/internal/formatter/testdata/update.input.sql
@@ -4,3 +4,5 @@ UPDATE o SET o.status='shipped' FROM orders AS o WHERE o.id=42;
 UPDATE o SET o.status='shipped' FROM orders AS o INNER JOIN customers AS c ON o.customer_id=c.id WHERE c.name='test';
 UPDATE o SET o.status='x',o.note='test' FROM orders AS o WHERE o.id=1 AND o.active=1;
 UPDATE o SET o.status='shipped' FROM orders AS o INNER JOIN customers AS c ON o.customer_id=c.id AND o.region=c.region WHERE c.name='test';
+
+UPDATE orders SET status='active' OPTION (MAXDOP 1);

--- a/internal/formatter/testdata/update.sql
+++ b/internal/formatter/testdata/update.sql
@@ -55,3 +55,10 @@ inner join
 		and o.region = c.region
 where
 	c.name = 'test';
+
+update
+	orders
+set
+	status = 'active'
+option
+	(maxdop 1);

--- a/internal/lexer/keywords.go
+++ b/internal/lexer/keywords.go
@@ -146,6 +146,7 @@ var keywords = map[string]bool{
 	"FETCH":     true,
 	"NEXT":      true,
 	"ONLY":      true,
+	"OPTION":    true,
 }
 
 // isKeyword reports whether word (any casing) is a SQL reserved word.

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -171,6 +171,7 @@ type SelectStmt struct {
 	Fetch         string        // n from FETCH NEXT n ROWS ONLY; empty if absent
 	ForKind       ForClauseKind // ForXML or ForJSON; ForNone if absent
 	ForOpts       string        // raw options after the XML/JSON mode keyword e.g. "PATH, ROOT('r')"; stored verbatim because FOR XML/JSON option linting is not yet in scope; empty if absent
+	Option        string        // raw content of OPTION(...) including surrounding parens e.g. "(recompile)"; stored verbatim because individual hint linting is not yet in scope; empty if absent
 }
 
 func (*SelectStmt) statementNode() {}

--- a/internal/parser/ast_dml.go
+++ b/internal/parser/ast_dml.go
@@ -12,7 +12,7 @@ type OutputClause struct {
 
 // --- DELETE -------------------------------------------------------------------
 
-// DeleteStmt represents: DELETE [TOP (n)] [<alias>] FROM <table> [AS <alias>] [OUTPUT …] [WHERE <predicate>].
+// DeleteStmt represents: DELETE [TOP (n)] [<alias>] FROM <table> [AS <alias>] [OUTPUT …] [WHERE <predicate>] [OPTION (…)].
 type DeleteStmt struct {
 	CTEs          []CTEDef      // WITH clause; nil if no CTEs
 	Top           string        // expression inside TOP(n); empty if absent
@@ -21,14 +21,15 @@ type DeleteStmt struct {
 	AliasExplicit bool          // true when the AS keyword preceded the alias
 	Output        *OutputClause // OUTPUT clause; nil if absent
 	Where         Expr          // WHERE predicate; nil if absent
+	Option        string        // raw content of OPTION(...) including surrounding parens; stored verbatim because individual hint linting is not yet in scope; empty if absent
 }
 
 func (*DeleteStmt) statementNode() {}
 
 // --- INSERT -------------------------------------------------------------------
 
-// InsertStmt represents INSERT INTO <table> [(cols)] [OUTPUT …] VALUES (...) [, (...)]
-// or INSERT INTO <table> [(cols)] [OUTPUT …] <select>.
+// InsertStmt represents INSERT INTO <table> [(cols)] [OUTPUT …] VALUES (...) [, (...)] [OPTION (…)]
+// or INSERT INTO <table> [(cols)] [OUTPUT …] <select> [OPTION (…)].
 // Exactly one of Values or Select is non-nil.
 type InsertStmt struct {
 	CTEs    []CTEDef // WITH clause; nil if no CTEs
@@ -37,6 +38,7 @@ type InsertStmt struct {
 	Output  *OutputClause // OUTPUT clause; nil if absent
 	Values  [][]Expr      // rows of value expressions; nil if Select is set
 	Select  *SelectStmt   // INSERT … SELECT form; nil if Values is set
+	Option  string        // raw content of OPTION(...) including surrounding parens; stored verbatim because individual hint linting is not yet in scope; empty if absent
 }
 
 func (*InsertStmt) statementNode() {}
@@ -62,8 +64,8 @@ type UpdateFromSource struct {
 
 // UpdateStmt represents an UPDATE statement.
 //
-// ANSI:       UPDATE [TOP (n)] <table> SET <col=expr> [WHERE <pred>]
-// SQL Server: UPDATE [TOP (n)] <alias> SET <col=expr> FROM <table> AS <alias> [JOINs] [WHERE <pred>]
+// ANSI:       UPDATE [TOP (n)] <table> SET <col=expr> [WHERE <pred>] [OPTION (…)]
+// SQL Server: UPDATE [TOP (n)] <alias> SET <col=expr> FROM <table> AS <alias> [JOINs] [WHERE <pred>] [OPTION (…)]
 //
 // When From is nil the statement is ANSI style and Target is the table name.
 // When From is non-nil the statement is SQL Server style: Target is the alias
@@ -76,6 +78,7 @@ type UpdateStmt struct {
 	Output *OutputClause     // OUTPUT clause; nil if absent
 	From   *UpdateFromSource // non-nil for SQL Server FROM style
 	Where  Expr              // WHERE predicate; nil if absent
+	Option string            // raw content of OPTION(...) including surrounding parens; stored verbatim because individual hint linting is not yet in scope; empty if absent
 }
 
 func (*UpdateStmt) statementNode() {}

--- a/internal/parser/parse_dml.go
+++ b/internal/parser/parse_dml.go
@@ -6,6 +6,21 @@ import (
 	"github.com/rpf3/sqlfmt/internal/lexer"
 )
 
+// parseOptionClause parses an OPTION (...) query hint clause and returns
+// the parenthesised content including surrounding parens, or empty string
+// if no OPTION keyword is present.
+func (p *parser) parseOptionClause() (string, error) {
+	if !p.curKeyword("OPTION") {
+		return "", nil
+	}
+	p.advance() // consume OPTION
+	raw, err := p.parseParenRaw()
+	if err != nil {
+		return "", err
+	}
+	return raw, nil
+}
+
 // parseTopClause parses an optional TOP (n) clause immediately after a DML
 // keyword (UPDATE, DELETE). Returns the expression string inside the parens,
 // or empty string if TOP is not present. PERCENT and WITH TIES are not valid
@@ -153,6 +168,12 @@ func (p *parser) parseInsert() (Statement, error) {
 		)
 	}
 
+	opt, err := p.parseOptionClause()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Option = opt
+
 	p.consumeSemicolon()
 	return stmt, nil
 }
@@ -220,9 +241,15 @@ func (p *parser) parseUpdate() (Statement, error) {
 	if p.curKeyword("WHERE") {
 		p.advance()
 		stmt.Where = p.parseAndChain(func() bool {
-			return p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
+			return p.curKeyword("OPTION") || p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
 		})
 	}
+
+	opt, err := p.parseOptionClause()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Option = opt
 
 	p.consumeSemicolon()
 	return stmt, nil
@@ -296,6 +323,7 @@ func (p *parser) parseSetClause() ([]UpdateSet, error) {
 				p.curKeyword("WHERE") ||
 				p.curKeyword("FROM") ||
 				p.curKeyword("OUTPUT") ||
+				p.curKeyword("OPTION") ||
 				p.curIs(lexer.Semicolon) ||
 				p.curIs(lexer.EOF)
 		})
@@ -364,9 +392,15 @@ func (p *parser) parseDelete() (Statement, error) {
 	if p.curKeyword("WHERE") {
 		p.advance()
 		stmt.Where = p.parseAndChain(func() bool {
-			return p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
+			return p.curKeyword("OPTION") || p.curIs(lexer.Semicolon) || p.curIs(lexer.EOF)
 		})
 	}
+
+	opt, err := p.parseOptionClause()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Option = opt
 
 	p.consumeSemicolon()
 

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -92,6 +92,7 @@ func (p *parser) parseSelectBranch() (*SelectStmt, error) {
 				p.curKeyword("WINDOW") ||
 				p.curKeyword("ORDER") || p.curKeyword("OFFSET") ||
 				p.curKeyword("FETCH") ||
+				p.curKeyword("OPTION") ||
 				p.isSetOpKeyword() ||
 				p.curIs(lexer.Semicolon) || p.curIs(lexer.RParen)
 		}
@@ -283,6 +284,12 @@ func (p *parser) parseSelectCore() (*SelectStmt, error) {
 		}
 		stmt.ForOpts = joinBodyTokens(tokBuf)
 	}
+
+	opt, err := p.parseOptionClause()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Option = opt
 
 	return stmt, nil
 }


### PR DESCRIPTION
## Summary

- Adds `OPTION (...)` query hint clause support to SELECT, INSERT, UPDATE, and DELETE statements
- Hint list is stored as a raw verbatim string on each statement's AST node — individual hint linting is out of scope (#177)
- Single hint formats inline; multiple hints use a vertical leading-comma block, consistent with other comma lists in sqlfmt
- Fixes WHERE and SET stop-functions in the parser that would have otherwise consumed the OPTION keyword as part of the predicate or assignment expression

## Test plan

- Golden file tests cover all four statement types: `select`, `insert`, `update`, `delete`
- SELECT: single hint `(recompile)`, multi-hint `(maxdop 4, recompile)`, hint after WHERE clause
- INSERT: VALUES form with hint, SELECT form with hint
- UPDATE: hint with no WHERE
- DELETE: hint after WHERE
- `TestFormatIdempotent` confirms round-trip stability for the multi-hint vertical block format

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)