### PR TITLE
feat: add VALUES row constructor as a FROM/JOIN source

### DIFF
--- a/internal/formatter/format_select.go
+++ b/internal/formatter/format_select.go
@@ -102,6 +102,36 @@ func (f *formatter) indentBodyStmt(stmt parser.Statement) string {
 	return b.String()
 }
 
+// writeValuesSource writes a VALUES(...) derived-table source into b.
+// The opening ( sits on its own line at root level (following the from/join
+// keyword line); the values keyword and each row paren are indented one level
+// via writeInListBlock; the closing ) as alias and optional column-alias list
+// follow at root level.
+func (f *formatter) writeValuesSource(b *strings.Builder, rows [][]parser.Expr, alias string, cols []string) {
+	ind := f.indent()
+	b.WriteString("\n(")
+	b.WriteString("\n" + ind + f.kw("values"))
+	for i, row := range rows {
+		rowStrs := make([]string, len(row))
+		for j, v := range row {
+			rowStrs[j] = parser.Render(v)
+		}
+		f.writeInListBlock(b, rowStrs)
+		if i < len(rows)-1 {
+			b.WriteString(",")
+		}
+	}
+	b.WriteString("\n)")
+	if alias != "" {
+		b.WriteString(" " + f.kw("as") + " " + f.ident(alias))
+	}
+	if len(cols) > 0 {
+		b.WriteString("\n(")
+		f.writeCommaList(b, cols)
+		b.WriteString("\n)")
+	}
+}
+
 // indentCTE formats s as a SELECT body with each non-empty line prefixed by
 // ind (single indent). Used for CTE bodies where the surrounding ( ) are at
 // column zero.
@@ -202,7 +232,7 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		cols = append(cols, c)
 	}
 
-	hasFrom := s.From.Name != "" || s.From.Subquery != nil
+	hasFrom := s.From.Name != "" || s.From.Subquery != nil || len(s.From.ValuesRows) > 0
 
 	// No-FROM SELECT: single column stays on the same line (e.g. "select 1;").
 	// When INTO is present the column list uses the normal multi-line style
@@ -234,6 +264,8 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 		if s.From.Alias != "" {
 			b.WriteString(" " + f.kw("as") + " " + f.ident(s.From.Alias))
 		}
+	} else if len(s.From.ValuesRows) > 0 {
+		f.writeValuesSource(&b, s.From.ValuesRows, s.From.Alias, s.From.ValuesCols)
 	} else {
 		b.WriteString("\n" + ind)
 		b.WriteString(f.ident(s.From.Name))
@@ -261,6 +293,15 @@ func (f *formatter) formatSelectStmt(s *parser.SelectStmt) string {
 			b.WriteString("\n" + ind + ")")
 			if jc.Alias != "" {
 				b.WriteString(" " + f.kw("as") + " " + f.ident(jc.Alias))
+			}
+		} else if len(jc.ValuesRows) > 0 {
+			f.writeValuesSource(&b, jc.ValuesRows, jc.Alias, jc.ValuesCols)
+			if jc.On != nil {
+				terms := parser.AndTerms(jc.On)
+				b.WriteString("\n" + ind + f.kw("on") + " " + parser.Render(terms[0]))
+				for _, term := range terms[1:] {
+					b.WriteString("\n" + ind + f.kw("and") + " " + parser.Render(term))
+				}
 			}
 		} else {
 			b.WriteString("\n" + ind + f.ident(jc.Name))

--- a/internal/formatter/testdata/select.input.sql
+++ b/internal/formatter/testdata/select.input.sql
@@ -37,3 +37,11 @@ SELECT t.col1 FROM dbo.t OPTION (RECOMPILE);
 SELECT t.col1 FROM dbo.t OPTION (MAXDOP 4, RECOMPILE);
 
 SELECT t.col1 FROM dbo.t WHERE t.id = 1 OPTION (RECOMPILE);
+
+SELECT s.status_code,s.label FROM (VALUES ('A','Active')) AS s (status_code,label);
+
+SELECT s.status_code,s.label FROM (VALUES ('A','Active'),('I','Inactive'),('P','Pending')) AS s (status_code,label);
+
+SELECT o.order_id,p.priority_label FROM orders AS o INNER JOIN (VALUES (1,'High'),(2,'Medium')) AS p (priority_id,priority_label) ON p.priority_id=o.priority_id;
+
+SELECT o.order_id,p.priority_label FROM orders AS o INNER JOIN (VALUES (1,'High'),(2,'Medium')) AS p (priority_id,priority_label) ON p.priority_id=o.priority_id WHERE o.status='active';

--- a/internal/formatter/testdata/select.sql
+++ b/internal/formatter/testdata/select.sql
@@ -385,3 +385,91 @@ where
 	t.id = 1
 option
 	(recompile);
+
+select
+	s.status_code
+,	s.label
+from
+(
+	values
+	(
+		'A'
+	,	'Active'
+	)
+) as s
+(
+	status_code
+,	label
+);
+
+select
+	s.status_code
+,	s.label
+from
+(
+	values
+	(
+		'A'
+	,	'Active'
+	),
+	(
+		'I'
+	,	'Inactive'
+	),
+	(
+		'P'
+	,	'Pending'
+	)
+) as s
+(
+	status_code
+,	label
+);
+
+select
+	o.order_id
+,	p.priority_label
+from
+	orders as o
+inner join
+(
+	values
+	(
+		1
+	,	'High'
+	),
+	(
+		2
+	,	'Medium'
+	)
+) as p
+(
+	priority_id
+,	priority_label
+)
+	on p.priority_id = o.priority_id;
+
+select
+	o.order_id
+,	p.priority_label
+from
+	orders as o
+inner join
+(
+	values
+	(
+		1
+	,	'High'
+	),
+	(
+		2
+	,	'Medium'
+	)
+) as p
+(
+	priority_id
+,	priority_label
+)
+	on p.priority_id = o.priority_id
+where
+	o.status = 'active';

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -52,13 +52,15 @@ const (
 // JoinClause is one JOIN clause attached to a SELECT's FROM source.
 type JoinClause struct {
 	Type          JoinType
-	Name          string      // joined table name; empty for APPLY subquery sources
+	Name          string      // joined table name; empty for APPLY subquery sources or VALUES sources
 	Hints         string      // table hints e.g. "(nolock)"; empty if none
 	Alias         string      // table alias; empty if none
 	AliasExplicit bool        // true when the AS keyword preceded the alias
 	On            Expr        // ON condition; nil for CROSS
 	TVFArgs       string      // parenthesised arg list for APPLY TVF sources e.g. "(@id)"; stored verbatim because TVF argument linting is not yet in scope; empty for regular joins
 	Subquery      *SelectStmt // subquery source for APPLY (SELECT ...) form; nil for regular joins
+	ValuesRows    [][]Expr    // non-nil when join source is a (VALUES (...), ...) row constructor
+	ValuesCols    []string    // column aliases declared after the table alias; nil if absent
 }
 
 // OrderItem is one term in an ORDER BY list.
@@ -121,13 +123,15 @@ type GroupByItem struct {
 }
 
 // SelectFromSource is the target of a FROM clause.
-// Exactly one of Name (a table name) or Subquery is non-zero.
+// Exactly one of Name (a table name), Subquery, or ValuesRows is non-zero.
 type SelectFromSource struct {
-	Name          string       // table name; empty for a subquery
+	Name          string       // table name; empty for a subquery or VALUES source
 	TVFArgs       string       // parenthesised arg list for TVF sources e.g. "(@id)"; stored verbatim because TVF argument linting is not yet in scope; empty for plain tables
 	Hints         string       // table hints e.g. "(nolock)"; empty if none
-	Subquery      *SelectStmt  // derived table; nil for a named table
-	Alias         string       // alias for either kind; empty if no alias
+	Subquery      *SelectStmt  // derived table; nil for a named table or VALUES source
+	ValuesRows    [][]Expr     // non-nil when source is a (VALUES (...), ...) row constructor; mutually exclusive with Name and Subquery
+	ValuesCols    []string     // column aliases declared after the table alias e.g. (status_code, label); nil if absent
+	Alias         string       // alias for any kind; empty if no alias
 	AliasExplicit bool         // true when the AS keyword preceded the alias
 	Pivot         *PivotClause // non-nil when a PIVOT or UNPIVOT operator follows the named source
 }

--- a/internal/parser/parse_select.go
+++ b/internal/parser/parse_select.go
@@ -343,6 +343,26 @@ func (p *parser) parseSelectItem() (SelectItem, error) {
 	return item, nil
 }
 
+// parseValuesRows parses a VALUES (...) [, (...)]... row list.
+// On entry: p.cur is the VALUES keyword.
+// On exit: p.cur is positioned after the last closing paren of the last row.
+func (p *parser) parseValuesRows() ([][]Expr, error) {
+	p.advance() // consume VALUES
+	var rows [][]Expr
+	for {
+		row, err := p.parseValueRow()
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+		if !p.curIs(lexer.Comma) {
+			break
+		}
+		p.advance() // consume ',' between rows
+	}
+	return rows, nil
+}
+
 // parseFromSource parses the target of a FROM clause: either a named table
 // or a derived table (SELECT ...) subquery. Bare aliases (without AS) are
 // also accepted for the lint rule in #34.
@@ -369,6 +389,39 @@ func (p *parser) parseFromSource() (SelectFromSource, error) {
 		} else if p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent) {
 			source.Alias = p.cur.Value
 			p.advance()
+		}
+		return source, nil
+	}
+
+	// VALUES derived table: (VALUES (...) [, (...)]...) AS alias [(cols)]
+	if p.curIs(lexer.LParen) && p.peekKeyword("VALUES") {
+		p.advance() // consume (
+		rows, err := p.parseValuesRows()
+		if err != nil {
+			return SelectFromSource{}, err
+		}
+		if _, err := p.expect(lexer.RParen); err != nil {
+			return SelectFromSource{}, err
+		}
+		source := SelectFromSource{ValuesRows: rows}
+		if p.curKeyword("AS") {
+			p.advance()
+			aliasTok, err := p.expectIdent()
+			if err != nil {
+				return SelectFromSource{}, err
+			}
+			source.Alias = aliasTok.Value
+			source.AliasExplicit = true
+		} else if p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent) {
+			source.Alias = p.cur.Value
+			p.advance()
+		}
+		if p.curIs(lexer.LParen) {
+			cols, err := p.parseIdentList()
+			if err != nil {
+				return SelectFromSource{}, err
+			}
+			source.ValuesCols = cols
 		}
 		return source, nil
 	}
@@ -707,6 +760,52 @@ func (p *parser) parseJoinClauses() ([]JoinClause, error) {
 			} else if p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent) {
 				jc.Alias = p.cur.Value
 				p.advance()
+			}
+			joins = append(joins, jc)
+			continue
+		}
+
+		// VALUES derived table: (VALUES (...) [, (...)]...) AS alias [(cols)]
+		if p.curIs(lexer.LParen) && p.peekKeyword("VALUES") {
+			p.advance() // consume (
+			rows, err := p.parseValuesRows()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(lexer.RParen); err != nil {
+				return nil, err
+			}
+			jc := JoinClause{Type: joinType, ValuesRows: rows}
+			if p.curKeyword("AS") {
+				p.advance()
+				aliasTok, err := p.expectIdent()
+				if err != nil {
+					return nil, err
+				}
+				jc.Alias = aliasTok.Value
+				jc.AliasExplicit = true
+			} else if p.curIs(lexer.Ident) || p.curIs(lexer.QuotedIdent) {
+				jc.Alias = p.cur.Value
+				p.advance()
+			}
+			if p.curIs(lexer.LParen) {
+				cols, err := p.parseIdentList()
+				if err != nil {
+					return nil, err
+				}
+				jc.ValuesCols = cols
+			}
+			if p.curKeyword("ON") {
+				p.advance()
+				jc.On = p.parseAndChain(func() bool {
+					return p.isNextJoin() ||
+						p.curKeyword("WHERE") || p.curKeyword("GROUP") ||
+						p.curKeyword("HAVING") || p.curKeyword("ORDER") ||
+						p.curKeyword("OFFSET") || p.curKeyword("FETCH") ||
+						p.curKeyword("OPTION") ||
+						p.isSetOpKeyword() ||
+						p.curIs(lexer.Semicolon)
+				})
 			}
 			joins = append(joins, jc)
 			continue


### PR DESCRIPTION
## Summary

- Adds support for `(VALUES (...), ...) AS alias (cols)` as a derived-table source in FROM clauses and regular JOINs
- `ValuesRows [][]Expr` and `ValuesCols []string` added to both `SelectFromSource` and `JoinClause`; mutually exclusive with `Name` and `Subquery`
- `parseValuesRows()` shared helper reuses `parseValueRow` (already used by INSERT) — no duplication
- `writeValuesSource()` formatter helper: outer `(` at root level, `values` and row parens at one indent via `writeInListBlock`, column-alias list follows the table alias
- `on` clause for VALUES JOINs indented one level (not two) — double-indent is visually anchored by a table name at `\t`, which VALUES sources don't have

## Test plan

- Single-row VALUES in FROM with column alias list
- Multi-row VALUES in FROM (3 rows)
- VALUES in INNER JOIN with ON clause
- VALUES in INNER JOIN with ON + WHERE — verifies `on` at single indent reads clearly alongside `where` at root

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)