### PR TITLE
feat: add EXECUTE AS and REVERT statements

### DIFF
--- a/internal/formatter/format_proc.go
+++ b/internal/formatter/format_proc.go
@@ -392,3 +392,23 @@ func (f *formatter) formatExec(s *parser.ExecStmt) string {
 
 	return b.String()
 }
+
+// formatExecuteAs formats an EXECUTE AS security-context statement.
+// Produces "execute as <context>;" or "exec as <context>;", preserving
+// which keyword alias the user wrote. The context keyword (USER, LOGIN,
+// CALLER, SELF) has keyword casing applied; any string literal content
+// after the keyword is preserved verbatim.
+func (f *formatter) formatExecuteAs(s *parser.ExecuteAsStmt) string {
+	ctx := s.Context
+	if sp := strings.IndexByte(ctx, ' '); sp >= 0 {
+		ctx = f.kw(strings.ToLower(ctx[:sp])) + ctx[sp:]
+	} else {
+		ctx = f.kw(strings.ToLower(ctx))
+	}
+	return f.kw(s.Keyword) + " " + f.kw("as") + " " + ctx + ";"
+}
+
+// formatRevert formats a REVERT statement.
+func (f *formatter) formatRevert() string {
+	return f.kw("revert") + ";"
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -123,6 +123,10 @@ func (f *formatter) formatStatement(stmt parser.Statement) string {
 		return f.formatPrint(s)
 	case *parser.ExecStmt:
 		return f.formatExec(s)
+	case *parser.ExecuteAsStmt:
+		return f.formatExecuteAs(s)
+	case *parser.RevertStmt:
+		return f.formatRevert()
 	case *parser.TransactionStmt:
 		return f.formatTransaction(s)
 	case *parser.RawStmt:

--- a/internal/formatter/testdata/exec.input.sql
+++ b/internal/formatter/testdata/exec.input.sql
@@ -21,3 +21,12 @@ EXEC (@sql);
 
 -- sp_executesql with multiple arguments
 EXEC sp_executesql @sql, N'@id INT', @id = 42;
+
+-- EXECUTE AS security context
+EXECUTE AS USER = 'dbo';
+EXECUTE AS LOGIN = 'sa';
+EXECUTE AS CALLER;
+EXEC AS SELF;
+
+-- REVERT
+REVERT;

--- a/internal/formatter/testdata/exec.sql
+++ b/internal/formatter/testdata/exec.sql
@@ -20,3 +20,13 @@ exec sp_executesql
 	@sql
 ,	N'@id INT'
 ,	@id = 42;
+
+execute as user = 'dbo';
+
+execute as login = 'sa';
+
+execute as caller;
+
+exec as self;
+
+revert;

--- a/internal/lexer/keywords.go
+++ b/internal/lexer/keywords.go
@@ -82,6 +82,7 @@ var keywords = map[string]bool{
 	"ROLLBACK":     true,
 	"RETURN":       true,
 	"RETURNS":      true,
+	"REVERT":       true,
 	"WHILE":        true,
 	"BREAK":        true,
 	"CONTINUE":     true,

--- a/internal/parser/ast_proc.go
+++ b/internal/parser/ast_proc.go
@@ -297,3 +297,29 @@ type ExecStmt struct {
 }
 
 func (*ExecStmt) statementNode() {}
+
+// --- EXECUTE AS / REVERT ------------------------------------------------------
+
+// ExecuteAsStmt represents a T-SQL EXECUTE AS security-context statement.
+//
+//	EXECUTE AS USER    = 'name'
+//	EXECUTE AS LOGIN   = 'name'
+//	EXECUTE AS CALLER
+//	EXECUTE AS SELF
+//
+// Context holds the full suffix after the AS keyword verbatim (e.g.
+// "USER = 'dbo'", "CALLER"); stored verbatim because the formatter
+// emits it unchanged and no lint rule needs to decompose the variants.
+type ExecuteAsStmt struct {
+	Keyword string // "execute" or "exec" — preserves which alias the user wrote
+	Context string // e.g. "USER = 'dbo'", "LOGIN = 'sa'", "CALLER", "SELF"
+}
+
+func (*ExecuteAsStmt) statementNode() {}
+
+// RevertStmt represents a T-SQL REVERT statement.
+//
+//	REVERT
+type RevertStmt struct{}
+
+func (*RevertStmt) statementNode() {}

--- a/internal/parser/parse_proc.go
+++ b/internal/parser/parse_proc.go
@@ -609,6 +609,34 @@ func (p *parser) parseExec() (Statement, error) {
 	return stmt, nil
 }
 
+// parseExecuteAs parses an EXECUTE AS / EXEC AS security-context statement.
+// On entry p.cur is EXEC or EXECUTE and p.peek is AS.
+func (p *parser) parseExecuteAs() (Statement, error) {
+	kw := strings.ToLower(p.cur.Value)
+	p.advance() // consume EXEC or EXECUTE
+	p.advance() // consume AS
+
+	// Collect everything up to the semicolon as the raw context string.
+	var tokBuf []lexer.Token
+	for p.cur.Type != lexer.EOF && !p.curIs(lexer.Semicolon) {
+		tokBuf = append(tokBuf, p.cur)
+		p.advance()
+	}
+	p.consumeSemicolon()
+	return &ExecuteAsStmt{
+		Keyword: kw,
+		Context: joinBodyTokens(tokBuf),
+	}, nil
+}
+
+// parseRevert parses a REVERT statement.
+// On entry p.cur is REVERT.
+func (p *parser) parseRevert() (Statement, error) {
+	p.advance() // consume REVERT
+	p.consumeSemicolon()
+	return &RevertStmt{}, nil
+}
+
 // joinBodyTokens joins a slice of tokens into a whitespace-normalised string,
 // lowercasing keywords and applying SQL spacing conventions.
 func joinBodyTokens(tokens []lexer.Token) string {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -270,8 +270,14 @@ func (p *parser) parseStatement() (Statement, error) {
 	if p.curKeyword("PRINT") {
 		return p.parsePrint()
 	}
+	if (p.curKeyword("EXEC") || p.curKeyword("EXECUTE")) && p.peekKeyword("AS") {
+		return p.parseExecuteAs()
+	}
 	if p.curKeyword("EXEC") || p.curKeyword("EXECUTE") {
 		return p.parseExec()
+	}
+	if p.curKeyword("REVERT") {
+		return p.parseRevert()
 	}
 	return nil, fmt.Errorf(
 		"unexpected token %s %q at %d:%d",


### PR DESCRIPTION
## Summary

- Adds `ExecuteAsStmt` and `RevertStmt` AST nodes to `ast_proc.go`
- Dispatcher peeks for `AS` before dispatching `EXEC`/`EXECUTE` to `parseExec`, routing the security-context form to a new `parseExecuteAs` function
- `REVERT` keyword added to the lexer; `parseRevert` and `formatRevert` handle the bare statement
- Formatter preserves which alias the user wrote (`exec` vs `execute`) and applies keyword casing to the context keyword (USER, LOGIN, CALLER, SELF) while preserving string literal content

## Test plan

- Golden files in `exec.input.sql` / `exec.sql` cover all four `EXECUTE AS` variants and `REVERT`
- `TestFormatGolden/exec` passes; `TestFormatIdempotent` confirms round-trip stability
- `task fmt && task test && task vet && task lint` all pass

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)