### PR TITLE
feat: parse OUTPUT keyword on EXEC arguments

### DIFF
--- a/internal/formatter/format_proc.go
+++ b/internal/formatter/format_proc.go
@@ -378,22 +378,29 @@ func (f *formatter) formatExec(s *parser.ExecStmt) string {
 
 	// Dynamic SQL: EXEC (@expr)
 	if s.Proc == "" {
-		b.WriteString(" " + s.Args + ";")
+		b.WriteString(" " + s.Args[0].Value + ";")
 		return b.String()
 	}
 
 	b.WriteString(" " + f.ident(s.Proc))
 
-	if s.Args == "" {
+	if len(s.Args) == 0 {
 		b.WriteString(";")
 		return b.String()
 	}
 
-	args := splitDepthZeroCommas(s.Args)
-	if len(args) == 1 {
-		b.WriteString(" " + args[0] + ";")
+	rendered := make([]string, len(s.Args))
+	for i, arg := range s.Args {
+		if arg.IsOutput {
+			rendered[i] = arg.Value + " " + f.kw("output")
+		} else {
+			rendered[i] = arg.Value
+		}
+	}
+	if len(rendered) == 1 {
+		b.WriteString(" " + rendered[0] + ";")
 	} else {
-		f.writeCommaList(&b, args)
+		f.writeCommaList(&b, rendered)
 		b.WriteString(";")
 	}
 

--- a/internal/formatter/testdata/exec.input.sql
+++ b/internal/formatter/testdata/exec.input.sql
@@ -30,3 +30,12 @@ EXEC AS SELF;
 
 -- REVERT
 REVERT;
+
+-- single OUTPUT arg (stays on one line)
+EXEC dbo.usp_GetValue @result OUTPUT;
+
+-- named OUTPUT arg (stays on one line)
+EXEC dbo.usp_GetValue @result = @result OUTPUT;
+
+-- multiple args, some with OUTPUT
+EXEC dbo.usp_GetCustomer @customer_id = 42, @name = @name OUTPUT, @email = @email OUTPUT;

--- a/internal/formatter/testdata/exec.sql
+++ b/internal/formatter/testdata/exec.sql
@@ -30,3 +30,12 @@ execute as caller;
 exec as self;
 
 revert;
+
+exec dbo.usp_GetValue @result output;
+
+exec dbo.usp_GetValue @result = @result output;
+
+exec dbo.usp_GetCustomer
+	@customer_id = 42
+,	@name = @name output
+,	@email = @email output;

--- a/internal/linter/lint_proc.go
+++ b/internal/linter/lint_proc.go
@@ -8,45 +8,18 @@ import (
 	"github.com/rpf3/sqlfmt/internal/parser"
 )
 
-// splitArgs splits a raw EXEC argument string on depth-0 commas (commas not
-// inside parentheses). Returns nil when s is empty.
-func splitArgs(s string) []string {
-	if s == "" {
-		return nil
-	}
-	var parts []string
-	depth := 0
-	start := 0
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-		case ',':
-			if depth == 0 {
-				parts = append(parts, strings.TrimSpace(s[start:i]))
-				start = i + 1
-			}
-		}
-	}
-	parts = append(parts, strings.TrimSpace(s[start:]))
-	return parts
-}
-
 // checkExecStmt applies lint rules to an EXEC statement.
 func (l *linter) checkExecStmt(s *parser.ExecStmt) {
 	// Dynamic SQL and no-arg calls are exempt.
-	if s.Proc == "" || s.Args == "" {
+	if s.Proc == "" || len(s.Args) == 0 {
 		return
 	}
-	args := splitArgs(s.Args)
 	// Single positional arg is a common convention with no ordering ambiguity.
-	if len(args) <= 1 {
+	if len(s.Args) <= 1 {
 		return
 	}
-	for _, arg := range args {
-		if !strings.Contains(arg, "=") {
+	for _, arg := range s.Args {
+		if !strings.Contains(arg.Value, "=") {
 			l.warn(config.RuleExecNamedParams,
 				fmt.Sprintf("exec %s: use named parameters (@param = value) instead of positional arguments", s.Proc))
 			return

--- a/internal/parser/ast_proc.go
+++ b/internal/parser/ast_proc.go
@@ -279,22 +279,24 @@ func (*TransactionStmt) statementNode() {}
 
 // --- EXEC ---------------------------------------------------------------------
 
+// ExecArg represents a single argument in an EXEC / EXECUTE call.
+type ExecArg struct {
+	Value    string // argument expression, e.g. "@customer_id = 42" or "@val"
+	IsOutput bool   // true when the OUTPUT keyword follows the value
+}
+
 // ExecStmt represents a T-SQL EXEC / EXECUTE statement.
 //
 //	EXEC [[@retvar =] <proc_name>] [<args>]
 //	EXEC (<dynamic_sql_expr>)
 //
 // For a normal procedure call Proc holds the (schema-qualified) name and Args
-// holds the raw argument list (everything between the proc name and the
-// terminating semicolon). For a dynamic-SQL EXEC (e.g. EXEC (@sql)) Proc is
-// empty and Args holds the full parenthesised expression.
-//
-// Argument parsing is kept as a raw string to avoid combinatorial complexity;
-// a future issue can add structured argument nodes.
+// holds the structured argument list. For a dynamic-SQL EXEC (e.g. EXEC (@sql))
+// Proc is empty and Args holds one entry with the full parenthesised expression.
 type ExecStmt struct {
-	ReturnVar string // optional capture: @var in "@var = proc_name …"; empty if absent
-	Proc      string // procedure name, possibly schema-qualified; empty for dynamic SQL
-	Args      string // raw argument list; empty if no arguments
+	ReturnVar string    // optional capture: @var in "@var = proc_name …"; empty if absent
+	Proc      string    // procedure name, possibly schema-qualified; empty for dynamic SQL
+	Args      []ExecArg // structured argument list; nil if no arguments
 }
 
 func (*ExecStmt) statementNode() {}

--- a/internal/parser/parse_proc.go
+++ b/internal/parser/parse_proc.go
@@ -637,7 +637,7 @@ func (p *parser) parseExec() (Statement, error) {
 			tokBuf = append(tokBuf, p.cur)
 			p.advance()
 		}
-		stmt.Args = joinBodyTokens(tokBuf)
+		stmt.Args = []ExecArg{{Value: joinBodyTokens(tokBuf)}}
 		p.consumeSemicolon()
 		return stmt, nil
 	}
@@ -649,15 +649,39 @@ func (p *parser) parseExec() (Statement, error) {
 	}
 	stmt.Proc = procName
 
-	// Remaining tokens up to ; are the raw argument list.
+	// Parse structured argument list: split on depth-zero commas, detect OUTPUT.
+	var args []ExecArg
 	var tokBuf []lexer.Token
+	depth := 0
+
+	flushArg := func() {
+		if len(tokBuf) == 0 {
+			return
+		}
+		isOutput := false
+		if last := tokBuf[len(tokBuf)-1]; last.Type == lexer.Keyword && last.Value == "output" {
+			isOutput = true
+			tokBuf = tokBuf[:len(tokBuf)-1]
+		}
+		args = append(args, ExecArg{Value: joinBodyTokens(tokBuf), IsOutput: isOutput})
+		tokBuf = tokBuf[:0]
+	}
+
 	for p.cur.Type != lexer.EOF && !p.curIs(lexer.Semicolon) {
+		if p.curIs(lexer.LParen) {
+			depth++
+		} else if p.curIs(lexer.RParen) {
+			depth--
+		} else if p.curIs(lexer.Comma) && depth == 0 {
+			flushArg()
+			p.advance()
+			continue
+		}
 		tokBuf = append(tokBuf, p.cur)
 		p.advance()
 	}
-	if len(tokBuf) > 0 {
-		stmt.Args = joinBodyTokens(tokBuf)
-	}
+	flushArg()
+	stmt.Args = args
 
 	p.consumeSemicolon()
 	return stmt, nil


### PR DESCRIPTION
## Summary

- Introduces `ExecArg{Value string, IsOutput bool}` and replaces `ExecStmt.Args string` with `[]ExecArg`, paying off the intentional debt noted in the original godoc comment
- `parseExec` now splits arguments on depth-zero commas at the token level and detects the `OUTPUT` keyword at the end of each argument
- `formatExec` appends `output` (via `kw()` for correct case handling) when `IsOutput` is set
- Removes the `splitArgs` helper from the linter — `checkExecStmt` now operates directly on `[]ExecArg`

## Test plan

- Existing exec golden tests unchanged — no OUTPUT in existing cases
- Three new golden test cases: single OUTPUT arg (inline), named OUTPUT arg (inline), multiple args with OUTPUT (vertical block)
- `TestFormatIdempotent` passes for the exec golden file
- Linter `exec-named-params` rule: still fires for positional multi-args, still exempt for single arg and dynamic SQL

## Closes

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)