### PR TITLE
feat: add no-function-in-where lint rule

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,7 @@ const (
 	RuleNoNolockHint                = "no-nolock-hint"
 	RuleNoVarcharMax                = "no-varchar-max"
 	RulePreferThrow                 = "prefer-throw-over-raiserror"
+	RuleNoFunctionInWhere           = "no-function-in-where"
 )
 
 // knownRules is the set of valid lint rule names for config validation.
@@ -123,6 +124,7 @@ var knownRules = map[string]bool{
 	RuleNoNolockHint:                true,
 	RuleNoVarcharMax:                true,
 	RulePreferThrow:                 true,
+	RuleNoFunctionInWhere:           true,
 }
 
 // defaultOffRules are rules that are off unless explicitly enabled in config.
@@ -130,9 +132,10 @@ var knownRules = map[string]bool{
 // are legitimate in many codebases (e.g. WITH (NOLOCK) for read-heavy queries,
 // VARCHAR(MAX) for large-text columns).
 var defaultOffRules = map[string]bool{
-	RuleNoNolockHint: true,
-	RuleNoVarcharMax: true,
-	RulePreferThrow:  true,
+	RuleNoNolockHint:      true,
+	RuleNoVarcharMax:      true,
+	RulePreferThrow:       true,
+	RuleNoFunctionInWhere: true,
 }
 
 // DefaultSeverity returns the default severity for rule when no explicit

--- a/internal/linter/lint_dml.go
+++ b/internal/linter/lint_dml.go
@@ -19,6 +19,7 @@ func (l *linter) checkUpdateStmt(s *parser.UpdateStmt) {
 		l.warn(config.RuleUpdateWithoutWhere,
 			fmt.Sprintf("UPDATE on table %q has no WHERE clause", s.Target))
 	}
+	l.checkNoFunctionInWhere(s.Where)
 }
 
 func (l *linter) checkMergeStmt(s *parser.MergeStmt) {
@@ -56,4 +57,5 @@ func (l *linter) checkDeleteStmt(s *parser.DeleteStmt) {
 		l.warn(config.RuleDeleteWithoutWhere,
 			fmt.Sprintf("DELETE on table %q has no WHERE clause", s.Table))
 	}
+	l.checkNoFunctionInWhere(s.Where)
 }

--- a/internal/linter/lint_hints_test.go
+++ b/internal/linter/lint_hints_test.go
@@ -130,3 +130,45 @@ func TestLintNoNolockHint(t *testing.T) {
 		}
 	})
 }
+
+func TestLintNoFunctionInWhere(t *testing.T) {
+	const rule = config.RuleNoFunctionInWhere
+
+	t.Run("off by default", func(t *testing.T) {
+		checkRule(t, `select id from dbo.orders as o where year(o.created_at) = 2024;`, "")
+	})
+
+	t.Run("scalar function wrapping column warns", func(t *testing.T) {
+		checkRuleEnabled(t, `select id from dbo.orders as o where year(o.created_at) = 2024;`, rule)
+	})
+
+	t.Run("UPPER wrapping column warns", func(t *testing.T) {
+		checkRuleEnabled(t, `select id from dbo.customers as c where upper(c.status) = 'ACTIVE';`, rule)
+	})
+
+	t.Run("function in UPDATE WHERE warns", func(t *testing.T) {
+		checkRuleEnabled(t, `update dbo.orders set status = 'done' where year(created_at) = 2024;`, rule)
+	})
+
+	t.Run("function in DELETE WHERE warns", func(t *testing.T) {
+		checkRuleEnabled(t, `delete from dbo.orders where year(created_at) < 2020;`, rule)
+	})
+
+	t.Run("function wrapping @variable is clean", func(t *testing.T) {
+		checkRuleEnabledClean(t, `select id from dbo.orders as o where isnull(@param, 0) = 1;`, rule)
+	})
+
+	t.Run("no function in WHERE is clean", func(t *testing.T) {
+		checkRuleEnabledClean(t, `select id from dbo.orders as o where o.created_at >= '2024-01-01';`, rule)
+	})
+
+	t.Run("function with no column args is clean", func(t *testing.T) {
+		checkRuleEnabledClean(t, `select id from dbo.orders as o where o.created_at > getdate();`, rule)
+	})
+
+	t.Run("function in subquery WHERE warns", func(t *testing.T) {
+		checkRuleEnabled(t,
+			`select id from dbo.orders as o where o.id in (select id from dbo.items as i where year(i.created_at) = 2024);`,
+			rule)
+	})
+}

--- a/internal/linter/lint_select.go
+++ b/internal/linter/lint_select.go
@@ -115,6 +115,9 @@ func (l *linter) checkSelectStmt(s *parser.SelectStmt) {
 		}
 	}
 
+	// no-function-in-where
+	l.checkNoFunctionInWhere(s.Where)
+
 	// Recurse into subqueries and set-operation branches.
 	if s.From.Subquery != nil {
 		l.checkSelectStmt(s.From.Subquery)
@@ -130,6 +133,46 @@ func (l *linter) checkSelectStmt(s *parser.SelectStmt) {
 	for _, setOp := range s.SetOps {
 		l.checkSelectStmt(setOp.Select)
 	}
+}
+
+// checkNoFunctionInWhere walks a WHERE predicate Expr and warns for each
+// FunctionCallExpr that wraps at least one plain column reference. Function
+// calls are structured as BinaryExpr{Left: FunctionCallExpr, ...} by the
+// parser when followed by a comparison operator, so Walk reaches them.
+// Args that are plain identifiers (not @variables) are detected by inspecting
+// the rendered RawExpr text. e is nil when the statement has no WHERE clause.
+func (l *linter) checkNoFunctionInWhere(e parser.Expr) {
+	if e == nil {
+		return
+	}
+	parser.Walk(e, func(node parser.Expr) {
+		fn, ok := node.(*parser.FunctionCallExpr)
+		if !ok {
+			return
+		}
+		for _, arg := range fn.Args {
+			text := strings.TrimSpace(parser.Render(arg))
+			if text == "" || text == "*" {
+				continue
+			}
+			// Skip @variables, string/hex literals, numeric literals, and
+			// sub-expressions with operators or parens.
+			if strings.HasPrefix(text, "@") ||
+				strings.HasPrefix(text, "'") ||
+				strings.HasPrefix(text, "N'") ||
+				strings.HasPrefix(text, "0x") ||
+				strings.ContainsAny(text, "()+'\"") {
+				continue
+			}
+			if text != "" && text[0] >= '0' && text[0] <= '9' {
+				continue
+			}
+			l.warn(config.RuleNoFunctionInWhere,
+				fmt.Sprintf("function call %s() in WHERE clause wraps column %q; this prevents index seeks — rewrite as a sargable predicate",
+					fn.Name, text))
+			return // one warning per function call is enough
+		}
+	})
 }
 
 // checkNolockHint emits a no-nolock-hint warning when the hints string for a

--- a/internal/parser/parse_expr.go
+++ b/internal/parser/parse_expr.go
@@ -164,8 +164,11 @@ func (p *parser) parseAndChain(stopFn func() bool) Expr {
 
 // parseExprNode wraps parseExprRaw but lifts top-level function calls into
 // *FunctionCallExpr nodes. When the expression does not start with a function
-// call, or when the function call is only part of a larger expression (e.g.
+// call, or when the function call is part of a non-comparison expression (e.g.
 // count(*) + 1), it falls back to *RawExpr — preserving the Render invariant.
+// When a function call is followed immediately by a comparison operator (=, <>,
+// !=, <, >, <=, >=), it is structured as a BinaryExpr so that linters can walk
+// into the FunctionCallExpr (e.g. to detect non-sargable WHERE predicates).
 func (p *parser) parseExprNode(stopFn func() bool) Expr {
 	if p.cur.Type == lexer.Ident && p.peek.Type == lexer.LParen {
 		fn := p.parseFunctionCall()
@@ -173,12 +176,41 @@ func (p *parser) parseExprNode(stopFn func() bool) Expr {
 		if p.cur.Type == lexer.EOF || p.cur.Type == lexer.RParen || stopFn() {
 			return fn
 		}
-		// More tokens follow — render fn back to string and accumulate the rest.
+		// Function call followed by a comparison operator: preserve as BinaryExpr
+		// so the FunctionCallExpr remains walkable. Render output is identical.
+		if op, ok := p.curComparisonOp(); ok {
+			p.advance() // consume operator
+			rhs := p.parseExprNode(stopFn)
+			return &BinaryExpr{Left: fn, Op: op, Right: rhs}
+		}
+		// More tokens follow in a non-comparison context — render fn back to
+		// string and accumulate the rest.
 		rest, _ := p.parseExprRaw(stopFn)
 		return &RawExpr{Text: Render(fn) + " " + rest}
 	}
 	text, _ := p.parseExprRaw(stopFn)
 	return &RawExpr{Text: text}
+}
+
+// curComparisonOp reports whether the current token is a comparison operator
+// and returns its canonical string form. Used by parseExprNode to decide when
+// to build a structured BinaryExpr rather than falling back to RawExpr.
+func (p *parser) curComparisonOp() (string, bool) {
+	switch p.cur.Type { //nolint:exhaustive // only comparison operators are relevant
+	case lexer.Eq:
+		return "=", true
+	case lexer.NotEq:
+		return p.cur.Value, true // preserves <> or !=
+	case lexer.Lt:
+		return "<", true
+	case lexer.Gt:
+		return ">", true
+	case lexer.LtEq:
+		return "<=", true
+	case lexer.GtEq:
+		return ">=", true
+	}
+	return "", false
 }
 
 // parseFunctionCall parses a function call starting at the current Ident token.


### PR DESCRIPTION
## Summary

- Adds opt-in lint rule `no-function-in-where` (off by default) that warns when a scalar function wraps a plain column reference in a WHERE clause — a classic non-sargable predicate that prevents index seeks
- Applies to SELECT, UPDATE, and DELETE WHERE clauses; recurses into subqueries automatically
- Skips `@variable` arguments — only bare column references (e.g. `created_at`, `t.status`) trigger the warning
- Also required a targeted parser enhancement: `parseExprNode` now builds a `BinaryExpr` when a function call is immediately followed by a comparison operator (`=`, `<>`, `<`, `>`, `<=`, `>=`), making the `FunctionCallExpr` walkable by the linter. `Render` output is identical so no formatter golden tests are affected

## Why the parser change was needed

`WHERE YEAR(created_at) = 2024` was previously parsed as a flat `RawExpr` string — `parser.Walk` could not reach the `FunctionCallExpr` inside it. The `BinaryExpr` wrapping preserves round-trip fidelity while giving the linter (and any future rules) a structured left-hand side to inspect.

## Test plan

- [ ] `task fmt && task test && task vet && task lint` — all green, 0 lint issues
- [ ] Rule is off by default (no warnings without opt-in)
- [ ] `YEAR(col) = 2024`, `UPPER(col) = 'X'` in SELECT WHERE warn
- [ ] `YEAR(col)` in UPDATE/DELETE WHERE warns
- [ ] `ISNULL(@param, 0)` does not warn (variable arg)
- [ ] `getdate()` with no column arg does not warn
- [ ] Subquery WHERE fires rule
- [ ] All existing formatter golden tests pass (parser change is render-neutral)

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)