### PR TITLE
docs: avoid @ in commit subject lines to prevent GitHub mention rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ type: short imperative description
 - Types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`
 - No parenthetical scopes — `feat:` not `feat(pkg):`
 - Keep under 72 characters; use the imperative mood ("add", "fix", "remove" — not "added")
+- Avoid `@` in subject lines — GitHub renders `@word` in release notes as a user mention; describe SQL variables in prose instead (e.g. "assignment SELECT" rather than "SET @var = expr")
 
 **Body — the "why" section:**
 


### PR DESCRIPTION
## Summary

- GoReleaser builds release notes from commit messages; GitHub renders `@word` anywhere in the release body as a user mention
- SQL variable syntax (`@var`, `@@system`) was causing unrelated GitHub users to appear in the release contributors section
- Adds a rule to CLAUDE.md directing away from `@` in subject lines, with a prose alternative as an example

## Test plan

- [ ] Verify the new rule appears in the Commit messages section of CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)